### PR TITLE
Use Syntax colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 ## ONE dark UI theme
 
+A dark UI theme that adjusts to most Syntax themes.
+
 ![one-dark-ui](https://cloud.githubusercontent.com/assets/378023/5887665/e5ca740c-a421-11e4-94a2-0c25984fef3c.png)
 
-There is also a matching [Syntax theme](https://atom.io/themes/one-dark-syntax).
+There is a matching [Syntax theme](https://atom.io/themes/one-dark-syntax), but most other Syntax themes work fine as well.
+
+![ONE dark combos](https://cloud.githubusercontent.com/assets/378023/6142256/03ca3726-b1f6-11e4-82f6-e2c4e9b0aedf.png)
 
 ### Install
 
-This theme is installed by default with Atom and can be activated by going to the __Settings > Themes__ section and selecting it from the __UI Themes__ drop-down menu.
+This theme is installed by default with Atom and can be activated by going to the __Settings > Themes__ section and selecting "One Dark" from the __UI Themes__ drop-down menu.
+
+### FAQ
+
+__Why do the colors change when I switch Syntax themes.__
+This UI theme uses the same background color as the choosen Syntax theme. In case that Syntax theme has a light background color, it only uses its hue, but otherwise stays dark. This lets you use dark-light combos.

--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -39,7 +39,7 @@
   color: @text-color;
   text-shadow: 0 1px 0 hsla(0,0%,0%,.2);
 
-  & when (@ui-brightness > 50%) {
+  & when (@ui-lightness > 50%) {
     border-color: transparent; // hide border on light backgrounds
   }
 
@@ -87,7 +87,7 @@
   }
 
   // hide border on light backgrounds
-  & when (@ui-brightness > 50%) {
+  & when (@ui-lightness > 50%) {
     &.btn-primary:first-child,
     &.btn-info:first-child,
     &.btn-success:first-child,

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -127,6 +127,14 @@
     }
   }
 
+  .tab.active[data-type="TextEditor"] {
+    color: @tab-text-color-editor;
+    background-color: @tab-background-color-editor;
+    &:after {
+      border-bottom-color: @tab-background-color-editor;
+    }
+  }
+
   .placeholder {
     margin: 0;
     height: @tab-height + @tab-top-padding;

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -175,7 +175,6 @@
   left: 0;
   width: 2px;
   height: @tab-height + @tab-bottom-border-height;
-  border-bottom: 1px solid fade(@tab-border-color, 60%);
   background: @base-accent-color;
   transform: scaleY(0);
   transition: transform .08s;

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -7,24 +7,6 @@
 @theme-adjust-saturation: 0%; // -/+n%
 @theme-adjust-contrast:   0%;
 
-// TODO: Move into package.json
-@theme-base-color-1: hsl(220, 80%, 55%);
-@theme-base-color-2: hsl(260, 90%, 65%);
-@theme-base-color-3: hsl(320, 60%, 45%);
-@theme-base-color-4: hsl( 20, 75%, 50%);
-@theme-base-color-5: hsl(150, 60%, 40%);
-
-@theme-saturation-1: hsl(220, 100%, 55%); //   40%
-@theme-saturation-2: hsl(220,  75%, 55%); //   20%
-@theme-saturation-3: hsl(220,  50%, 55%); //    0%
-@theme-saturation-4: hsl(220,  25%, 55%); //  -10%
-@theme-saturation-5: hsl(220,   0%, 55%); // -100%
-
-@theme-contrast-1: hsla(0, 0%, 100%,  1); //  40%
-@theme-contrast-2: hsla(0, 0%, 100%, .8); //  20%
-@theme-contrast-3: hsla(0, 0%, 100%, .6); //   0%
-@theme-contrast-4: hsla(0, 0%, 100%, .4); // -10%
-@theme-contrast-5: hsla(0, 0%, 100%, .2); // -20%
 
 
 // Config -----------------------------------

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -36,6 +36,9 @@
 @base-background-color: @ui-color;
 @base-border-color:     hsl(@ui-hue, @ui-saturation, @ui-lightness*.7);
 
+// Editor colors -----------------------------------
+@ui-editor-background-color: @ui-a;
+
 
 // Level Colors -----------------------------------
 
@@ -70,6 +73,8 @@
 @tab-text-color:                   @text-color-highlight;
 @tab-icon-color:                   @text-color-subtle;
 @tab-inactive-transparency:        .5;
+@tab-background-color-editor:      @ui-editor-background-color;
+@tab-text-color-editor:            contrast(@ui-editor-background-color, darken(@ui-editor-background-color, 50%), @text-color-highlight );
 
 @pane-item-background-color:       @base-background-color;
 @pane-item-border-color:           @base-border-color;

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -1,37 +1,50 @@
+@import "syntax-variables";
 
-// UI Variables for Atom Theme: One Dark
+// ONE dark UI variables
+// -----------------------------------
 
-// Settings -----------------------------------
+// Debug (console.log for Less)
+// html:before {
+//   content: "@{variable}";
+// }
 
-@theme-color:             hsl(220, 100%, 50%);
-@theme-adjust-saturation: 0%; // -/+n%
-@theme-adjust-contrast:   0%;
+// Adjust -----------------------------------
 
+@ui-a:       hsl(252, 11%, 18%); // fallback
+@ui-a:       @syntax-background-color;
+
+// Goal: use @syntax-background-color if it's dark enough, otherwise use same hue but stay dark
+// The light up by 100% is done to trick contrast() into picking one of 2 dark colors
+@ui-a-h:     hue(@ui-a);
+@ui-a-s:     min( saturation(@ui-a), 12%);
+@ui-a-l:     luma(@ui-a) + 100%; // (1) light up
+@ui-a-light: hsl(@ui-a-h, @ui-a-s, @ui-a-l); // (2) flashed color
+@ui-a-color: contrast(@ui-a-light, @ui-a, hsl(@ui-a-h, @ui-a-s, 24%) ); // (3) use @ui-a if darker than 24%
 
 
 // Config -----------------------------------
 
-@ui-hue:         hsvhue(@theme-color);
-@ui-saturation: max(20% + @theme-adjust-saturation, 0%); // limit to > 0%
-@ui-brightness:     20%;
-@ui-contrast:       @theme-adjust-contrast * 0.1;
+@ui-hue:        hue(@ui-a-color);
+@ui-saturation: saturation(@ui-a-color);
+@ui-lightness:  lightness(@ui-a-color);
+@ui-color:      @ui-a-color;
 
 
 // Base colors -----------------------------------
 
-@base-accent-color:     hsl(@ui-hue, @theme-adjust-saturation + 90%, (@ui-brightness + (@ui-contrast*10) + 40%) );
-@base-background-color: hsv(@ui-hue, @ui-saturation, @ui-brightness);
-@base-border-color:     hsv(@ui-hue, @ui-saturation, @ui-brightness*.7);
+@base-accent-color:     hsl(@ui-hue, @ui-saturation + 70%, @ui-lightness + 40%);
+@base-background-color: @ui-color;
+@base-border-color:     hsl(@ui-hue, @ui-saturation, @ui-lightness*.7);
 
 
 // Level Colors -----------------------------------
 
-@level-1-color: lighten(@base-background-color, @ui-contrast + 6%);
-@level-2-color:  darken(@base-background-color, @ui-contrast);
-@level-3-color:  darken(@base-background-color, @ui-contrast + 3%);
+@level-1-color: lighten(@base-background-color, 6%);
+@level-2-color: @base-background-color;
+@level-3-color: darken(@base-background-color, 3%);
 
 
-// Var + State Background Colors
+// Var + State Background Colors -------------------------------------
 
 @background-color-info:    hsl(208, 100%, 50%);
 @background-color-success: hsl(160,  70%, 42%);
@@ -42,7 +55,7 @@
 @background-color-selected: lighten(@base-background-color, 8%);
 
 
-// Component Colors
+// Component Colors -------------------------------------
 
 @app-background-color:             darken(@level-3-color, 2%);
 
@@ -108,12 +121,12 @@
 @key-binding-background-color: hsla(0,0%,100%,.1);
 
 
-// Text Colors
+// Text Colors -------------------------------------
 
-@text-color: hsl(@ui-hue, @ui-saturation, max(30%, (@ui-brightness + @ui-contrast) * 3) );
+@text-color: hsl(@ui-hue, @ui-saturation, max(30%, @ui-lightness * 3) );
 @text-color-subtle: fadeout(@text-color, 40%);
 @text-color-faded: fade(@text-color, 20%);
-@text-color-highlight: hsl(@ui-hue, @ui-saturation*8, @ui-contrast*10 + 88%);
+@text-color-highlight: hsl(@ui-hue, @ui-saturation*8, 88%);
 @text-color-selected: white;
 
 @text-color-info:    hsl(219,  79%, 66%);
@@ -128,7 +141,7 @@
 @text-color-renamed:  @text-color-info;     // blue
 
 
-// Sizes
+// Sizes -------------------------------------
 
 @font-size:       11px;
 @input-font-size: 14px;
@@ -144,12 +157,12 @@
 @tab-height: 30px;
 
 
-// Font
+// Font -------------------------------------
 
 @font-family: 'Lucida Grande', 'Segoe UI', sans-serif;
 
 
-// Settings View
+// Settings View -------------------------------------
 
 @settings-list-background-color: darken(@level-2-color, 1.5%);
 @theme-config-box-shadow: inset 0 0 3px hsla(0, 0%, 100%, .4), 0 1px 3px hsla(0, 0%, 0%, .2);


### PR DESCRIPTION
Until or maybe even as an alternative to #9, this PR imports the Syntax variables and changes the UI based on the syntax background color. This makes it more flexible to use with other than the matching One dark Syntax theme.

### Todo

- [x] Use syntax vars
- [x] Seamless tab for light Syntax themes (depends on https://github.com/atom/tabs/pull/118)
- [x] Update README

### Some examples:

Test theme (unpublished)
![screen shot 2015-02-05 at 4 40 11 pm](https://cloud.githubusercontent.com/assets/378023/6056785/4796ef68-ad59-11e4-8bab-7bdae7b1f518.png)

Atom
![screen shot 2015-02-06 at 11 00 48 am](https://cloud.githubusercontent.com/assets/378023/6073276/7a2ebbae-adef-11e4-97ed-f18368d6abbf.png)

Monokai
![screen shot 2015-02-05 at 4 40 43 pm](https://cloud.githubusercontent.com/assets/378023/6056786/5029837a-ad59-11e4-9362-72bbc85dd277.png)

Hannah
![screen shot 2015-02-05 at 4 41 08 pm](https://cloud.githubusercontent.com/assets/378023/6056792/5841651e-ad59-11e4-9897-fa9ede548d57.png)

If you pick a light Syntax theme, the UI stays dark but still uses its hue. Here the Sepia theme:
![screen shot 2015-02-05 at 4 42 39 pm](https://cloud.githubusercontent.com/assets/378023/6056814/98607fb8-ad59-11e4-93ad-2b062893fdf4.png)