### PR TITLE
markdown-preview

### DIFF
--- a/styles/packages.less
+++ b/styles/packages.less
@@ -57,8 +57,9 @@
 // markdown-preview ---------------------------
 .markdown-preview {
   font-size: @font-size*1.25;
-  color: @text-color;
-  background-color: @base-background-color;
+  color: @markdown-preview-color;
+  background-color: @markdown-preview-background-color;
+
 
   h1, h2 {
     color: inherit;
@@ -79,31 +80,23 @@
   }
 
   code {
-    color: lighten(@text-color, 20%);
+    color: @markdown-preview-code-color;
     border-color: @base-border-color;
-    background-color: lighten(@base-background-color, 10%);
+    background-color: @markdown-preview-code-background-color;
     background-clip: padding-box;
   }
 
-  atom-text-editor {
-    background-color: @level-3-color;
-    &::shadow {
-      .lines {
-        background-color: @level-3-color;
-      }
-      .line.cursor-line {
-        background-color: transparent;
-      }
+  atom-text-editor::shadow {
+    .line.cursor-line {
+      background-color: transparent;
     }
   }
 }
 
-/* Active tab for default background
+// Active tab for default background
 .tab.active[data-type="MarkdownPreviewView"] {
-  color: @tab-text-color-editor;
-  background-color: #fff;
+  background-color: @markdown-preview-background-color;
   &:after {
-    border-bottom-color: #fff;
+    border-bottom-color: @markdown-preview-background-color;
   }
 }
-*/

--- a/styles/packages.less
+++ b/styles/packages.less
@@ -56,8 +56,58 @@
 
 // markdown-preview ---------------------------
 .markdown-preview {
-  font-size: @font-size;
+  font-size: @font-size*1.25;
+  color: @text-color;
+  background-color: @base-background-color;
+
+  h1, h2 {
+    color: inherit;
+    border-color: @base-border-color;
+  }
+
+  a {
+    color: @text-color-highlight;
+  }
+
+  hr {
+    background-color: @text-color-subtle;
+  }
+
+  blockquote {
+    color: @text-color;
+    border-left-color: @text-color-subtle;
+  }
+
+  code {
+    color: lighten(@text-color, 20%);
+    border-color: @base-border-color;
+    background-color: lighten(@base-background-color, 10%);
+    background-clip: padding-box;
+  }
+
+  atom-text-editor {
+    background-color: @level-3-color;
+    &::shadow {
+      .lines {
+        background-color: @level-3-color;
+      }
+      .line.cursor-line {
+        background-color: transparent;
+      }
+    }
+  }
 }
+
+/* Active tab for default background
+.tab.active[data-type="MarkdownPreviewView"] {
+  color: @tab-text-color-editor;
+  background-color: #fff;
+  &:after {
+    border-bottom-color: #fff;
+  }
+}
+*/
+
 
 
 // git-control ---------------------------

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -148,13 +148,6 @@
       border-bottom-color: @tab-background-color-editor;
     }
   }
-  .tab.active[data-type="MarkdownPreviewView"] {
-    color: @tab-text-color-editor;
-    background-color: #fff;
-    &:after {
-      border-bottom-color: #fff;
-    }
-  }
 
   .placeholder {
     margin: 0;

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -168,9 +168,15 @@ html { font-size: 11px; }   // base font-size
 @font-family: 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;
 
 
-// Settings View -------------------------------------
+// Packages -------------------------------------
 
 @settings-list-background-color: darken(@level-2-color, 1.5%);
 @theme-config-box-shadow: inset 0 0 3px hsla(0, 0%, 100%, .4), 0 1px 3px hsla(0, 0%, 0%, .2);
 @theme-config-box-shadow-selected: inset 0 1px 3px hsla(0, 0%, 0%, .1);
 @theme-config-border-selected: hsla(0, 0%, 100%, .75);
+
+@markdown-preview-color: lighten(@text-color, 15%);
+@markdown-preview-background-color: lighten(@base-background-color, 3%);
+@markdown-preview-hr-color: lighten(@base-background-color, 3%);
+@markdown-preview-code-color: lighten(@text-color, 30%);
+@markdown-preview-code-background-color: lighten(@base-background-color, 10%);


### PR DESCRIPTION
This styles the `markdown-preview` package so it matches the theme colors.

Before:

![screen shot 2015-03-04 at 4 54 12 pm](https://cloud.githubusercontent.com/assets/378023/6479915/664099f4-c290-11e4-91a0-ebc93f2430a8.png)

After:

![screen shot 2015-03-04 at 4 52 55 pm](https://cloud.githubusercontent.com/assets/378023/6479917/6d6cf150-c290-11e4-95a1-fe2ebc80ea3f.png)
