### PR TITLE
Saturation guards

### DIFF
--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -5,22 +5,13 @@
 @import "syntax-variables";
 
 // Config -----------------
-@ui-s:       @syntax-background-color;
-@ui-s-h:     hue(@ui-s);
-@ui-s-s:     min( saturation(@ui-s), 12%);
-@ui-s-l:     luma(@ui-s);
+@ui-syntax-color: @syntax-background-color;
 
-.ui-s-color() when (@ui-s-l <= 50%) { @ui-s-color: @ui-s; }
-.ui-s-color() when (@ui-s-l > 50%)  { @ui-s-color: hsl(@ui-s-h, @ui-s-s, 24%); }
-.ui-s-color(); // ^ Use @syntax-background-color if dark, otherwise only use hue + saturation
+@ui-hue:          hue(@ui-syntax-color);
+@ui-saturation:   min( saturation(@ui-syntax-color),  8%);
+@ui-lightness:    min(  lightness(@ui-syntax-color), 26%);
 
-
-// Main UI colors -----------------
-@ui-hue:          hue(@ui-s-color);
-@ui-saturation:   saturation(@ui-s-color);
-@ui-lightness:    lightness(@ui-s-color);
-@ui-color:        @ui-s-color; // normalized @syntax-background-color
-@ui-syntax-color: @ui-s;       // original @syntax-background-color
+@ui-color:        hsl(@ui-hue, @ui-saturation, @ui-lightness); // normalized @syntax-background-color
 
 
 

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -3,15 +3,26 @@
 ** ---------------------------------------------- */
 
 @import "syntax-variables";
-
-// Config -----------------
 @ui-syntax-color: @syntax-background-color;
 
-@ui-hue:          hue(@ui-syntax-color);
-@ui-saturation:   min( saturation(@ui-syntax-color),  8%);
-@ui-lightness:    min(  lightness(@ui-syntax-color), 26%);
+// Color guards -----------------
+@ui-hue: hue(@ui-syntax-color);
 
-@ui-color:        hsl(@ui-hue, @ui-saturation, @ui-lightness); // normalized @syntax-background-color
+@ui-s-s: saturation(@ui-syntax-color);
+.ui-saturation() when (@ui-hue <=  80) { @ui-saturation: min(@ui-s-s,  6%); } // minimize saturation for brown
+.ui-saturation() when (@ui-hue >   80)
+                  and (@ui-hue <  160) { @ui-saturation: min(@ui-s-s, 12%); } // reduce saturation for green
+.ui-saturation() when (@ui-hue >= 160) { @ui-saturation: min(@ui-s-s, 24%); } // limit max saturaiotn for the rest
+.ui-saturation();
+
+@ui-s-l: lightness(@ui-syntax-color);
+.ui-lightness() when (@ui-s-l <  16%) { @ui-lightness: @ui-s-l + 6%; } // increase lightness when too dark
+.ui-lightness() when (@ui-s-l >= 16%) { @ui-lightness: min(@ui-s-l, 22%); } // limit max lightness
+.ui-lightness();
+
+// Main colors -----------------
+@ui-fg: hsl(@ui-hue, min(@ui-saturation, 18%), max(@ui-lightness*3, 60%) );
+@ui-bg: hsl(@ui-hue, @ui-saturation, @ui-lightness); // normalized @syntax-background-color
 
 
 
@@ -24,7 +35,7 @@
 
 
 // Text -----------------
-@text-color:            hsl(@ui-hue, min(40%, @ui-saturation), max(50%, @ui-lightness * 3) );
+@text-color:            @ui-fg;
 @text-color-subtle:     fadeout(@text-color, 40%);
 @text-color-highlight:  hsl(@ui-hue, @ui-saturation*8, 88%);
 @text-color-selected:   white;
@@ -48,7 +59,7 @@
 
 
 // Base -----------------
-@base-background-color: @ui-color;
+@base-background-color: @ui-bg;
 @base-border-color:     hsl(@ui-hue, @ui-saturation, @ui-lightness*.7);
 
 


### PR DESCRIPTION
This PR adds some color guards. Fixes #22 

It limits saturation more for __brown/green__ colors, but keeps it the same strong for __blue/purple__. Below an example with `One dark` + `Printen`.

Before:
![screen shot 2015-03-20 at 10 17 02 am](https://cloud.githubusercontent.com/assets/378023/6744265/965d8474-ceea-11e4-9c8b-fa53d1b7a61c.png)

After:
![screen shot 2015-03-20 at 10 16 20 am](https://cloud.githubusercontent.com/assets/378023/6744268/9f0edc80-ceea-11e4-890c-d9d57d78c931.png)

In other words.. make it look less like :hankey: and more like :chocolate_bar:.

---

Also in case a Syntax theme is very dark (like Atom dark), the UI flips around to be lighter than the Syntax background. So that there is still a noticeable difference.

Before:
![screen shot 2015-03-20 at 10 17 40 am](https://cloud.githubusercontent.com/assets/378023/6744269/a6915528-ceea-11e4-8d9d-cac2f9a28ae8.png)

After:
![screen shot 2015-03-20 at 10 18 20 am](https://cloud.githubusercontent.com/assets/378023/6744270/ac1f23c6-ceea-11e4-913b-d839d8e66c58.png)