### PR TITLE
Ensure button icons have the right text color

### DIFF
--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -50,6 +50,11 @@
   &:focus {
     color: @text-color;
   }
+
+
+  &.icon:before {
+    color: @text-color;
+  }
 }
 
 


### PR DESCRIPTION
Buttons with `.btn-success` were showing with gray icons instead of white. This should make every icon match the text color.

e.g. package updating in the settings view:

![screen shot 2015-04-01 at 09 04 08](https://cloud.githubusercontent.com/assets/1759837/6936988/d8ba4708-d84f-11e4-8adc-97981bc3bb84.png)

Now:
![screen shot 2015-04-01 at 09 09 32](https://cloud.githubusercontent.com/assets/1759837/6936990/dc85ca24-d84f-11e4-9682-8e20e03e71ba.png)

