### PR TITLE
Use px in ui-variables

### DIFF
--- a/styles/atom.less
+++ b/styles/atom.less
@@ -2,12 +2,16 @@
 	box-sizing: border-box;
 }
 
+html {
+	font-size: @font-size;
+}
+
 atom-workspace {
-	padding-right: @component-padding/2;
+	padding-right: @ui-padding/2;
 	background-color: @app-background-color;
 
 	atom-panel-container.left:empty {
-		padding-left: @component-padding/2;
+		padding-left: @ui-padding/2;
 	}
 
 }

--- a/styles/badges.less
+++ b/styles/badges.less
@@ -1,14 +1,14 @@
 .badge {
-  padding: @component-padding/4 @component-padding/2.5;
-  min-width: @component-padding*1.25;
+  padding: @ui-padding/4 @ui-padding/2.5;
+  min-width: @ui-padding*1.25;
   .text(highlight);
-  border-radius: @font-size*2;
+  border-radius: @ui-size*2;
   background-color: @badge-background-color;
 
   // Icon ----------------------
   &.icon {
-    font-size: @font-size;
-    padding: @component-icon-padding @component-icon-padding*1.5;
+    font-size: @ui-size;
+    padding: @ui-padding-icon @ui-padding-icon*1.5;
   }
 
 }

--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -1,6 +1,6 @@
 
 @btn-border: 1px solid @button-border-color;
-@btn-padding: 0 @font-size/1.25;
+@btn-padding: 0 @ui-size/1.25;
 
 // Mixins -----------------------
 
@@ -63,6 +63,8 @@
 .btn {
   height: initial;
   padding: @btn-padding;
+  font-size: @ui-size;
+  line-height: @ui-line-height;
 }
 
 .btn,
@@ -91,20 +93,20 @@
 
 .btn.btn-xs,
 .btn-group-xs > .btn {
-  font-size: @font-size*.8;
-  line-height: @component-line-height;
+  font-size: @ui-size*.8;
+  line-height: @ui-line-height;
   padding: @btn-padding;
 }
 .btn.btn-sm,
 .btn-group-sm > .btn {
-  font-size: @font-size*.9;
-  line-height: @component-line-height;
+  font-size: @ui-size*.9;
+  line-height: @ui-line-height;
   padding: @btn-padding;
 }
 .btn.btn-lg,
 .btn-group-lg > .btn {
-  font-size: @font-size * 1.5;
-  line-height: @component-line-height;
+  font-size: @ui-size * 1.5;
+  line-height: @ui-line-height;
   padding: @btn-padding;
 }
 

--- a/styles/core.less
+++ b/styles/core.less
@@ -23,7 +23,7 @@ atom-notifications {
       padding-right: 40px;
     }
     .item {
-      padding: @component-padding/2;
+      padding: @ui-padding/2;
     }
     &.icon:before {
       padding-top: .85em;
@@ -64,9 +64,9 @@ atom-notifications {
   // Components
   atom-panel.modal:after {
     position: absolute;  // prevent overlay backdrop from leaking outside
-    left: -@component-padding;
-    right: -@component-padding;
-    bottom: -@component-padding;
+    left: -@ui-padding;
+    right: -@ui-padding;
+    bottom: -@ui-padding;
   }
 
   atom-panel.modal:after {

--- a/styles/core.less
+++ b/styles/core.less
@@ -34,6 +34,7 @@ atom-notifications {
 // Styleguide ----------------------------------------------
 
 .styleguide {
+  font-size: inherit;
   padding: 0;
 
   section.bordered,

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,10 +1,19 @@
 atom-text-editor[mini] {
+  line-height: @component-line-height;
+  max-height: @component-line-height + 2; // +2 for borders
+  overflow: auto;
+}
+
+atom-text-editor[mini] {
+  font-size: @ui-input-size;
+  line-height: @ui-line-height;
+  max-height: none;
   padding-left: 0;
   border-radius: @component-border-radius;
   color: @text-color-highlight;
   border: 1px solid @input-border-color;
   background-color: @input-background-color;
-  padding-left: @component-padding/2;
+  padding-left: @ui-padding/2;
 
   &,
   &::shadow {

--- a/styles/key-binding.less
+++ b/styles/key-binding.less
@@ -1,11 +1,11 @@
 .key-binding {
   display: inline-block;
-  margin-left: @component-icon-padding;
-  padding: 0 @component-padding/4;
+  margin-left: @ui-padding-icon;
+  padding: 0 @ui-padding/4;
   line-height: 2;
   font-family: Helvetica Neue, Arial, sans-serif;
-  font-size: max(1em, @font-size*.85);
-  letter-spacing: @font-size/10;
+  font-size: max(1em, @ui-size*.85);
+  letter-spacing: @ui-size/10;
   border-radius: @component-border-radius;
   border: 1px solid @key-binding-border-color;
   background-color: @key-binding-background-color;

--- a/styles/lists.less
+++ b/styles/lists.less
@@ -99,21 +99,22 @@
 }
 
 .select-list.popover-list {
+  @popover-list-padding: @ui-padding/4;
   background-color: @overlay-background-color;
   box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.3);
-  padding: @ui-padding/2;
+  padding: @popover-list-padding;
   border-radius: @component-border-radius;
 
   atom-text-editor[mini] {
-    margin-bottom: @ui-padding/2;
+    margin-bottom: @popover-list-padding;
   }
 
   ol.list-group {
-    margin-top: @ui-padding/2;
+    margin-top: @popover-list-padding;
   }
 
   .list-group li {
-    padding-left: @ui-padding/2;
+    padding-left: @popover-list-padding;
   }
 }
 

--- a/styles/lists.less
+++ b/styles/lists.less
@@ -43,7 +43,7 @@
   }
 
   .no-icon {
-    padding-left: calc(@component-icon-padding ~"+" @component-icon-size);
+    padding-left: calc(@ui-padding-icon ~"+" @component-icon-size);
   }
 }
 
@@ -86,12 +86,12 @@
       width: @active-icon-size;
     }
     > li:not(.active):before {
-      margin-right: @component-icon-padding;
+      margin-right: @ui-padding-icon;
     }
     li.active {
       .octicon(check, @active-icon-size);
       &:before {
-        margin-right: @component-icon-padding;
+        margin-right: @ui-padding-icon;
         color: @text-color-success;
       }
     }
@@ -101,19 +101,19 @@
 .select-list.popover-list {
   background-color: @overlay-background-color;
   box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.3);
-  padding: @component-padding/2;
+  padding: @ui-padding/2;
   border-radius: @component-border-radius;
 
   atom-text-editor[mini] {
-    margin-bottom: @component-padding/2;
+    margin-bottom: @ui-padding/2;
   }
 
   ol.list-group {
-    margin-top: @component-padding/2;
+    margin-top: @ui-padding/2;
   }
 
   .list-group li {
-    padding-left: @component-padding/2;
+    padding-left: @ui-padding/2;
   }
 }
 
@@ -131,12 +131,12 @@
 
 li.ui-draggable-dragging,
 li.ui-sortable-helper {
-  line-height: @component-line-height;
-  height: @component-line-height;
+  line-height: @ui-line-height;
+  height: @ui-line-height;
   border: 0;
   border-radius: 0;
   list-style: none;
-  padding: 0 @component-padding;
+  padding: 0 @ui-padding;
   background: @background-color-highlight;
   box-shadow: 0 0 1px @base-border-color;
 }

--- a/styles/modal.less
+++ b/styles/modal.less
@@ -1,15 +1,15 @@
 
-@modal-padding: @component-padding/2 @component-padding/1.5;
+@modal-padding: @ui-padding/2 @ui-padding/1.5;
 
 atom-panel.modal {
-  width: @font-size * 40;
-  margin-left: @font-size * -20;
+  width: @ui-size * 40;
+  margin-left: @ui-size * -20;
   color: @text-color;
   background-color: transparent;
-  padding: @component-padding;
+  padding: @ui-padding;
 
   atom-text-editor[mini] {
-    margin-bottom: @component-padding;
+    margin-bottom: @ui-padding;
   }
 
   .select-list ol.list-group,
@@ -32,7 +32,7 @@ atom-panel.modal {
 
       .status.icon {
         float: right;
-        margin-left: @component-icon-padding;
+        margin-left: @ui-padding-icon;
         &:before {
           margin-right: 0;
         }
@@ -48,8 +48,8 @@ atom-panel.modal {
 
   .select-list .key-binding {
     margin-top: -1px;
-    margin-left: @component-padding/2;
-    margin-right: calc( -@component-padding/3 ~"+" 1px);
+    margin-left: @ui-padding/2;
+    margin-right: calc( -@ui-padding/3 ~"+" 1px);
   }
 
   & > * {

--- a/styles/modal.less
+++ b/styles/modal.less
@@ -6,10 +6,10 @@ atom-panel.modal {
   margin-left: @ui-size * -20;
   color: @text-color;
   background-color: transparent;
-  padding: @ui-padding;
+  padding: @ui-padding/2;
 
   atom-text-editor[mini] {
-    margin-bottom: @ui-padding;
+    margin-bottom: @ui-padding/2;
   }
 
   .select-list ol.list-group,
@@ -24,6 +24,7 @@ atom-panel.modal {
 
     li {
       padding: @modal-padding;
+      line-height: @ui-line-height;
       border-bottom: 1px solid @overlay-border-color;
 
       &:last-of-type {
@@ -50,6 +51,10 @@ atom-panel.modal {
     margin-top: -1px;
     margin-left: @ui-padding/2;
     margin-right: calc( -@ui-padding/3 ~"+" 1px);
+  }
+
+  .select-list .primary-line {
+    display: block;
   }
 
   & > * {

--- a/styles/packages.less
+++ b/styles/packages.less
@@ -1,6 +1,16 @@
 // Overrides packages
 
-// find-and-replace ---------------------------
+// find-and-replace + project-find ---------------------------
+
+.find-and-replace,
+.project-find {
+  padding: @ui-padding/4;
+  .input-block-item {
+    padding: @ui-padding/4;
+  }
+}
+
+// find-and-replace
 .find-and-replace {
   .header,
   .input-block {
@@ -23,17 +33,19 @@
   .btn-group-options .btn,
   .btn-group-options .btn.option-selection,
   .btn-group-options .btn.option-whole-word {
-    font-size: @ui-size*1.25;
+    padding: 0;
+    font-size: @ui-input-size; // keep same as text input
   }
 
   .find-container atom-text-editor {
     padding-right: @ui-size*5; // leave some room for the results count
   }
   .find-meta-container {
-    top: .66em;
+    top: 0;
+    font-size: @ui-size;
+    line-height: @ui-size*2.66;
   }
 }
-
 
 // project-find
 .project-find {
@@ -54,12 +66,14 @@
     padding: 0;
   }
   .btn-group-options .btn {
-    font-size: @ui-size*1.25;
+    padding: 0;
+    font-size: @ui-input-size; // keep same as text input
   }
 }
 
 
 // markdown-preview ---------------------------
+
 .markdown-preview {
   font-size: @ui-size*1.25;
   color: @markdown-preview-color;

--- a/styles/packages.less
+++ b/styles/packages.less
@@ -4,30 +4,30 @@
 .find-and-replace {
   .header,
   .input-block {
-    min-width: @font-size*25;
+    min-width: @ui-size*25;
   }
 
   .input-block-item {
-    flex: 1 1 @font-size*25;
+    flex: 1 1 @ui-size*25;
   }
   .input-block-item--flex {
-    flex: 100 1 @font-size*25;
+    flex: 100 1 @ui-size*25;
   }
 
   .btn,
   .btn-group-options .btn {
-    font-size: @font-size*1.1;
+    font-size: @ui-size*1.1;
     padding: 0;
   }
 
   .btn-group-options .btn,
   .btn-group-options .btn.option-selection,
   .btn-group-options .btn.option-whole-word {
-    font-size: @font-size*1.25;
+    font-size: @ui-size*1.25;
   }
 
   .find-container atom-text-editor {
-    padding-right: @font-size*5; // leave some room for the results count
+    padding-right: @ui-size*5; // leave some room for the results count
   }
   .find-meta-container {
     top: .66em;
@@ -39,29 +39,29 @@
 .project-find {
   .header,
   .input-block {
-    min-width: @font-size*15;
+    min-width: @ui-size*15;
   }
 
   .input-block-item {
-    flex: 1 1 @font-size*10;
+    flex: 1 1 @ui-size*10;
   }
   .input-block-item--flex {
-    flex: 100 1 @font-size*20;
+    flex: 100 1 @ui-size*20;
   }
 
   .btn {
-    font-size: @font-size*1.1;
+    font-size: @ui-size*1.1;
     padding: 0;
   }
   .btn-group-options .btn {
-    font-size: @font-size*1.25;
+    font-size: @ui-size*1.25;
   }
 }
 
 
 // markdown-preview ---------------------------
 .markdown-preview {
-  font-size: @font-size*1.25;
+  font-size: @ui-size*1.25;
   color: @markdown-preview-color;
   background-color: @markdown-preview-background-color;
 

--- a/styles/panes.less
+++ b/styles/panes.less
@@ -2,7 +2,7 @@
 atom-pane-container {
   atom-pane {
     position: relative;
-    padding-top: @component-padding/2;
+    padding-top: @ui-padding/2;
 
     .item-views {
       border: 1px solid @pane-item-border-color;

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -2,15 +2,15 @@
 // Settings
 
 // Modular Scale (1.125): http://www.modularscale.com/?1&em&1.125&web&table
-@ms-6: @font-size * 2.027;
-@ms-5: @font-size * 1.802;
-@ms-4: @font-size * 1.602;
-@ms-3: @font-size * 1.424;
-@ms-2: @font-size * 1.266;
-@ms-1: @font-size * 1.125;
-@ms-0: @font-size * 1;
-@ms_1: @font-size * 0.889;
-@ms_2: @font-size * 0.790;
+@ms-6: @ui-size * 2.027;
+@ms-5: @ui-size * 1.802;
+@ms-4: @ui-size * 1.602;
+@ms-3: @ui-size * 1.424;
+@ms-2: @ui-size * 1.266;
+@ms-1: @ui-size * 1.125;
+@ms-0: @ui-size * 1;
+@ms_1: @ui-size * 0.889;
+@ms_2: @ui-size * 0.790;
 
 
 
@@ -20,8 +20,8 @@
 
 	.config-menu {
 		position: relative;
-		min-width: @font-size * 15;
-		max-width: @font-size * 20;
+		min-width: @ui-size * 15;
+		max-width: @ui-size * 20;
 		border-width: 0 1px 0 0;
 		border-image: linear-gradient(@level-2-color 10px, @base-border-color 200px) 0 1 0 0 stretch;
 		background: @level-2-color;
@@ -30,7 +30,7 @@
 			white-space: initial;
 			font-size: @ms_1;
 			line-height: 1;
-			padding: @component-padding/3 @component-padding/2;
+			padding: @ui-padding/3 @ui-padding/2;
 			&::before {
 				vertical-align: middle;
 			}
@@ -40,8 +40,8 @@
 	}
 	.nav {
 		& > li > a {
-			padding: @component-padding/2 @component-padding;
-			line-height: @component-line-height;
+			padding: @ui-padding/2 @ui-padding;
+			line-height: @ui-line-height;
 		}
 	}
 
@@ -49,32 +49,32 @@
 	// Sections ------------------------------
 
 	.section-container {
-		max-width: @font-size*60;
+		max-width: @ui-size*60;
 	}
 	.sub-section {
-		margin: @component-padding*3 0;
+		margin: @ui-padding*3 0;
 	}
 
 	.section,
 	.section:first-child,
 	.section:last-child {
-		padding: @component-padding*3;
+		padding: @ui-padding*3;
 	}
 
 	.themes-panel .control-group {
-		margin-top: @component-padding*2;
+		margin-top: @ui-padding*2;
 	}
 
 
 	// Titles ------------------------------
 
 	.section .section-heading {
-		margin-bottom: @component-padding/1.5;
+		margin-bottom: @ui-padding/1.5;
 	}
 
 	.sub-section-heading.icon:before,
 	.section-heading.icon:before {
-		margin-right: @component-icon-padding;
+		margin-right: @ui-padding-icon;
 	}
 
 
@@ -82,9 +82,9 @@
 	// Cards ------------------------------
 
 	.package-card {
-		padding: @component-padding;
+		padding: @ui-padding;
 		.meta-controls .status-indicator {
-			width: @component-padding/4;
+			width: @ui-padding/4;
 			&:before {
 				content: "\00a0"; // fixes 0 height
 			}
@@ -99,14 +99,19 @@
 	}
 
 	.editor-container {
-		margin: @component-padding 0;
+		margin: @ui-padding 0;
 	}
 
 	.form-control {
-		font-size: @font-size*1.25;
-		height: @component-line-height;
+		font-size: @ui-size*1.25;
+		height: @ui-line-height;
 		padding-top: 0;
 		padding-bottom: 0;
+
+		/deep/ option {
+			color: red;
+		}
+
 	}
 
 }

--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -1,8 +1,8 @@
-@status-bar-height: @component-padding*1.75;
-@status-bar-padding: @component-padding;
+@status-bar-height: @ui-padding*1.75;
+@status-bar-padding: @ui-padding;
 
 .status-bar {
-  font-size: @font-size;
+  font-size: @ui-size;
   height: @status-bar-height;
   line-height: @status-bar-height;
 

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -1,12 +1,12 @@
 @tab-border-size: 1px;
 @tab-border: @tab-border-size solid @tab-border-color;
-@tab-max-width: @font-size*15;
-@tab-min-width: @font-size*5;
-@tab-padding: @component-padding/2;
-@modified-icon-width: @font-size*1.5;
+@tab-max-width: @ui-size*15;
+@tab-min-width: @ui-size*5;
+@tab-padding: @ui-padding/2;
+@modified-icon-width: @ui-size*1.5;
 
 .tab-bar {
-  height: @tab-height;
+  height: @ui-tab-height;
   box-shadow: inset 0 -1px 0 @tab-border-color;
   background: @tab-bar-background-color;
   overflow-x: auto;
@@ -23,9 +23,9 @@
     top: 0;
     max-width: @tab-max-width;
     min-width: @tab-min-width;
-    height: @tab-height;
+    height: @ui-tab-height;
     font-size: inherit;
-    line-height: @tab-height;
+    line-height: @ui-tab-height;
     padding: 0;
     margin: 0;
 
@@ -83,8 +83,8 @@
       right: 0;
       z-index: 1;
       margin-right: @tab-padding*1.2;
-      height: @tab-height;
-      line-height: @tab-height;
+      height: @ui-tab-height;
+      line-height: @ui-tab-height;
       text-align: center;
       color: @tab-icon-color;
       transform: scale(0);
@@ -139,7 +139,7 @@
       right: 0;
       top: 0;
       width: initial;
-      height: @tab-height;
+      height: @ui-tab-height;
       border: none;
       border-bottom: @tab-border-size solid transparent;
       border-radius: 0;
@@ -173,11 +173,11 @@
 
   .placeholder {
     margin: 0;
-    height: @tab-height;
+    height: @ui-tab-height;
     background: @base-accent-color;
     pointer-events: none;
     &:after {
-      top: @tab-height/2;
+      top: @ui-tab-height/2;
       width: 10px;
       height: 10px;
       margin: -5px 0 0 0;

--- a/styles/tooltips.less
+++ b/styles/tooltips.less
@@ -1,6 +1,6 @@
 .tooltip {
   white-space: nowrap;
-  font-size: @font-size*1.15;
+  font-size: @ui-size*1.15;
 
   &.in {
     opacity: 1;
@@ -9,7 +9,7 @@
 
   .tooltip-inner {
     line-height: 1;
-    padding: @component-padding*.5 @component-padding*.65;
+    padding: @ui-padding*.5 @ui-padding*.65;
     border-radius: @component-border-radius;
     background-color: @tooltip-background-color;
     color: @tooltip-text-color;
@@ -19,9 +19,9 @@
 
   .keystroke {
     font-family: "Helvetica Neue", Arial, sans-serif;
-    font-size: max(1em, @font-size*.85);
+    font-size: max(1em, @ui-size*.85);
     padding: .1em .4em;
-    margin: 0 @component-padding*-.35 0 @component-padding*.25;
+    margin: 0 @ui-padding*-.35 0 @ui-padding*.25;
     border-radius: max(2px, @component-border-radius / 2);
     color: @tooltip-text-key-color;
     background: @tooltip-background-key-color;

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -1,18 +1,18 @@
-@tree-view-height: @component-padding*1.5;
+@tree-view-height: @ui-padding*1.5;
 
 .tree-view {
-  font-size: @font-size;
+  font-size: @ui-size;
   background: @tree-view-background-color;
 
   .project-root.project-root {
-    padding-top: @component-padding/2;
+    padding-top: @ui-padding/2;
     &:before {
-      height: @tab-height;
+      height: @ui-tab-height;
       border-top: 1px solid transparent;
       background-clip: padding-box;
     }
     & > .header .name {
-      line-height: @tab-height;
+      line-height: @ui-tab-height;
     }
   }
 

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -105,17 +105,17 @@
 
 
 // Sizes -----------------
-@font-size:               1em;
-@input-font-size:         @font-size*1.25;
-@disclosure-arrow-size:   @font-size;
+@font-size:               11px;
+@input-font-size:         14px;
+@disclosure-arrow-size:   12px;
 
-@component-padding:       @font-size*1.5;
-@component-icon-padding:  @component-padding/3.3;
+@component-padding:       10px;
+@component-icon-padding:  5px;
 @component-icon-size:     16px; // needs to stay 16px to look sharpest
-@component-line-height:   @font-size*2;
+@component-line-height:   25px;
 @component-border-radius: 3px;
 
-@tab-height:              @component-padding*2;
+@tab-height:              30px;
 
 
 // Font -----------------
@@ -184,8 +184,13 @@
 
 
 // Sizes (Custom) -----------------
-html { font-size: 11px; } // base font-size
 
+@ui-size:                 1em;
+@ui-input-size:           @ui-size*1.25;
+@ui-padding:              @ui-size*1.5;
+@ui-padding-icon:         @ui-padding/3.3;
+@ui-line-height:          @ui-size*2;
+@ui-tab-height:           @ui-padding*2;
 
 
 


### PR DESCRIPTION
This PR adds `px` units to the `ui-variables`, but still keeps using `em`s internally. In other words..

- This will give packages that use the `ui-variables` a fixed size and be more predictable.
- The core UI and bundled packages can still be scaled from styles.less.

Fixes: #37, https://github.com/atom/deprecation-cop/issues/34