### PR TITLE
Layout Modes

### DIFF
--- a/index.less
+++ b/index.less
@@ -28,3 +28,4 @@
 @import "styles/settings";
 @import "styles/packages";
 @import "styles/core";
+@import "styles/config";

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -1,6 +1,6 @@
 module.exports =
 
-  apply: () ->
+  apply: ->
 
     body = document.querySelector('html')
 

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -1,0 +1,13 @@
+module.exports =
+
+  apply: () ->
+
+    body = document.querySelector('html')
+
+    setLayoutMode = (layoutMode) ->
+      body.setAttribute('theme-one-dark-ui-layoutmode', layoutMode)
+
+    atom.config.onDidChange 'one-dark-ui.layoutMode', ->
+      setLayoutMode(atom.config.get('one-dark-ui.layoutMode'))
+
+    setLayoutMode(atom.config.get('one-dark-ui.layoutMode'))

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -5,7 +5,7 @@ module.exports =
     body = document.querySelector('html')
 
     setLayoutMode = (layoutMode) ->
-      body.setAttribute('theme-one-dark-ui-layoutmode', layoutMode)
+      body.setAttribute('theme-one-dark-ui-layoutmode', layoutMode.toLowerCase())
 
     atom.config.onDidChange 'one-dark-ui.layoutMode', ->
       setLayoutMode(atom.config.get('one-dark-ui.layoutMode'))

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -2,10 +2,10 @@ module.exports =
 
   apply: ->
 
-    body = document.querySelector('html')
+    root = document.documentElement
 
     setLayoutMode = (layoutMode) ->
-      body.setAttribute('theme-one-dark-ui-layoutmode', layoutMode.toLowerCase())
+      root.setAttribute('theme-one-dark-ui-layoutmode', layoutMode.toLowerCase())
 
     atom.config.onDidChange 'one-dark-ui.layoutMode', ->
       setLayoutMode(atom.config.get('one-dark-ui.layoutMode'))

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -2,7 +2,7 @@ module.exports =
   config:
     layoutMode:
       title: 'Layout Mode'
-      description: 'In auto mode, the UI and font size will automatically change based on the window size.'
+      description: 'In Auto mode, the UI and font size will automatically change based on the window size.'
       type: 'string'
       default: 'Auto'
       enum: [

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -1,0 +1,17 @@
+module.exports =
+  config:
+    layoutMode:
+      title: 'Layout Mode'
+      description: 'In auto mode, the UI and font size will automatically change based on the window size.'
+      type: 'string'
+      default: 'auto'
+      enum: [
+        'compact',
+        'auto',
+        'spacious',
+      ]
+
+  activate: (state) ->
+    atom.themes.onDidChangeActiveThemes ->
+      Config = require './config'
+      Config.apply()

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -4,11 +4,11 @@ module.exports =
       title: 'Layout Mode'
       description: 'In auto mode, the UI and font size will automatically change based on the window size.'
       type: 'string'
-      default: 'auto'
+      default: 'Auto'
       enum: [
-        'compact',
-        'auto',
-        'spacious',
+        'Compact',
+        'Auto',
+        'Spacious',
       ]
 
   activate: (state) ->

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "license": "MIT",
   "repository": "https://github.com/atom/one-dark-ui",
+  "main": "lib/settings",
   "engines": {
     "atom": ">0.40.0"
   }

--- a/styles/config.less
+++ b/styles/config.less
@@ -1,0 +1,32 @@
+// Compact mode ----------------------------------------------
+
+html {
+  font-size: @font-size*1.25;
+}
+
+@media (max-width: 1200px), (max-height: 600px) {
+
+  html {
+  	font-size: @font-size;
+  }
+
+  atom-workspace {
+    padding-right: 0;
+    atom-panel-container.left:empty {
+      padding-left: 0;
+    }
+  }
+
+  atom-pane-container atom-pane {
+    padding-top: 0;
+  }
+
+  .tree-view .project-root.project-root {
+    padding-top: 0;
+  }
+
+  .tab-bar .tab::after {
+    border-radius: 0;
+  }
+
+}

--- a/styles/config.less
+++ b/styles/config.less
@@ -6,12 +6,12 @@ html { font-size: @font-size; }
 
 // Large screen (>= 27")
 @media (min-width: 2560px) {
-  [theme-one-dark-ui-layoutmode="Auto"] { font-size: @font-size + 2px; }
+  [theme-one-dark-ui-layoutmode="auto"] { font-size: @font-size + 2px; }
 }
 
 // Medium screen (>= 20")
 @media (min-width: 1920px) {
-  [theme-one-dark-ui-layoutmode="Auto"] { font-size: @font-size + 1px; }
+  [theme-one-dark-ui-layoutmode="auto"] { font-size: @font-size + 1px; }
 }
 
 // Small screen (<= 13")
@@ -58,12 +58,12 @@ html { font-size: @font-size; }
   }
 }
 
-[theme-one-dark-ui-layoutmode="Compact"] {
+[theme-one-dark-ui-layoutmode="compact"] {
   .compact-mode();
 }
 
 @media (max-width: 1280px), (max-height: 800px) {
-  [theme-one-dark-ui-layoutmode="Auto"] {
+  [theme-one-dark-ui-layoutmode="auto"] {
     .compact-mode();
   }
 }

--- a/styles/config.less
+++ b/styles/config.less
@@ -6,12 +6,12 @@ html { font-size: @font-size; }
 
 // Large screen (>= 27")
 @media (min-width: 2560px) {
-  [theme-one-dark-ui-layoutmode="auto"] { font-size: @font-size + 2px; }
+  [theme-one-dark-ui-layoutmode="Auto"] { font-size: @font-size + 2px; }
 }
 
 // Medium screen (>= 20")
 @media (min-width: 1920px) {
-  [theme-one-dark-ui-layoutmode="auto"] { font-size: @font-size + 1px; }
+  [theme-one-dark-ui-layoutmode="Auto"] { font-size: @font-size + 1px; }
 }
 
 // Small screen (<= 13")
@@ -55,12 +55,12 @@ html { font-size: @font-size; }
   }
 }
 
-[theme-one-dark-ui-layoutmode="compact"] {
+[theme-one-dark-ui-layoutmode="Compact"] {
   .compact-mode();
 }
 
 @media (max-width: 1280px), (max-height: 800px) {
-  [theme-one-dark-ui-layoutmode="auto"] {
+  [theme-one-dark-ui-layoutmode="Auto"] {
     .compact-mode();
   }
 }

--- a/styles/config.less
+++ b/styles/config.less
@@ -1,17 +1,19 @@
 // Compact mode ----------------------------------------------
 
+@theme-layoutmode: ~'theme-@{ui-theme-name}-layoutmode';
+
 // Default
 html { font-size: @font-size; }
 
 
 // Large screen (>= 27")
 @media (min-width: 2560px) {
-  [theme-one-dark-ui-layoutmode="auto"] { font-size: @font-size + 2px; }
+  [@{theme-layoutmode}="auto"] { font-size: @font-size + 2px; }
 }
 
 // Medium screen (>= 20")
 @media (min-width: 1920px) {
-  [theme-one-dark-ui-layoutmode="auto"] { font-size: @font-size + 1px; }
+  [@{theme-layoutmode}="auto"] { font-size: @font-size + 1px; }
 }
 
 // Small screen (<= 13")
@@ -58,12 +60,12 @@ html { font-size: @font-size; }
   }
 }
 
-[theme-one-dark-ui-layoutmode="compact"] {
+[@{theme-layoutmode}="compact"] {
   .compact-mode();
 }
 
 @media (max-width: 1280px), (max-height: 800px) {
-  [theme-one-dark-ui-layoutmode="auto"] {
+  [@{theme-layoutmode}="auto"] {
     .compact-mode();
   }
 }

--- a/styles/config.less
+++ b/styles/config.less
@@ -1,13 +1,18 @@
 // Compact mode ----------------------------------------------
 
-html {
-  font-size: @font-size*1.25;
+// Medium screen
+html { font-size: @font-size; }
+
+// Large screen
+@media (min-width: 1690px), (min-height: 950px) {
+  html { font-size: @font-size + 2px; }
 }
 
-@media (max-width: 1200px), (max-height: 600px) {
+// Small screen (<= 13")
+@media (max-width: 1280px), (max-height: 800px) {
 
   html {
-  	font-size: @font-size;
+    font-size: @font-size - 1px;
   }
 
   atom-workspace {
@@ -21,12 +26,28 @@ html {
     padding-top: 0;
   }
 
+  .tab-bar {
+    border-radius: 0; // TODO: move to tabs.less
+    .tab::before,
+    .tab::after {
+      border-radius: 0;
+    }
+  }
+
+
+  // tree-view
   .tree-view .project-root.project-root {
     padding-top: 0;
   }
 
-  .tab-bar .tab::after {
-    border-radius: 0;
+  .list-group li:not(.list-nested-item),
+  .list-tree li:not(.list-nested-item),
+  .list-group li.list-nested-item > .list-item, .list-tree li.list-nested-item > .list-item {
+    line-height: @ui-line-height*.92;
+  }
+  .list-group .selected::before,
+  .list-tree .selected::before {
+    height: @ui-line-height*.92;
   }
 
 }

--- a/styles/config.less
+++ b/styles/config.less
@@ -1,19 +1,23 @@
 // Compact mode ----------------------------------------------
 
-// Medium screen
+// Default
 html { font-size: @font-size; }
 
-// Large screen
-@media (min-width: 1690px), (min-height: 950px) {
-  html { font-size: @font-size + 2px; }
+
+// Large screen (>= 27")
+@media (min-width: 2560px) {
+  [theme-one-dark-ui-layoutmode="auto"] { font-size: @font-size + 2px; }
+}
+
+// Medium screen (>= 20")
+@media (min-width: 1920px) {
+  [theme-one-dark-ui-layoutmode="auto"] { font-size: @font-size + 1px; }
 }
 
 // Small screen (<= 13")
-@media (max-width: 1280px), (max-height: 800px) {
 
-  html {
-    font-size: @font-size - 1px;
-  }
+.compact-mode() {
+  font-size: @font-size - 1px;
 
   atom-workspace {
     padding-right: 0;
@@ -49,5 +53,14 @@ html { font-size: @font-size; }
   .list-tree .selected::before {
     height: @ui-line-height*.92;
   }
+}
 
+[theme-one-dark-ui-layoutmode="compact"] {
+  .compact-mode();
+}
+
+@media (max-width: 1280px), (max-height: 800px) {
+  [theme-one-dark-ui-layoutmode="auto"] {
+    .compact-mode();
+  }
 }

--- a/styles/config.less
+++ b/styles/config.less
@@ -42,6 +42,9 @@ html { font-size: @font-size; }
   // tree-view
   .tree-view .project-root.project-root {
     padding-top: 0;
+    &:before {
+      height: @ui-tab-height;
+    }
   }
 
   .list-group li:not(.list-nested-item),

--- a/styles/core.less
+++ b/styles/core.less
@@ -1,5 +1,11 @@
 // Misc
 
+// Remove extra space
+// TODO: fix in core/background-tips
+atom-workspace .horizontal atom-pane-resize-handle.vertical {
+  position: absolute;
+}
+
 .preview-pane .results-view .path-match-number {
   // show number also on selected item
   color: inherit;

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -1,4 +1,4 @@
-@tree-view-height: @ui-padding*1.5;
+@tree-view-height: @ui-line-height;
 
 .tree-view {
   font-size: @ui-size;

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -105,7 +105,7 @@
 
 
 // Sizes -----------------
-@font-size:               11px;
+@font-size:               12px;
 @input-font-size:         14px;
 @disclosure-arrow-size:   12px;
 

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -129,6 +129,8 @@
 ** These variables are only used in this theme
 ** ---------------------------------------------- */
 
+@ui-theme-name: one-dark-ui;
+
 // Text (Custom) -----------------
 @text-color-faded: fade(@text-color, 20%);
 


### PR DESCRIPTION
This PR adds 3 layout modes that can be changed in the settings. Closes #40

![screen shot 2015-04-29 at 1 30 21 pm](https://cloud.githubusercontent.com/assets/378023/7384739/ee4f85f8-ee73-11e4-9a7a-43cdf888ec7a.png)

- `spacious`. Like the current "framed" version, but with `12px` font size (instead of `11px`).
- `compact`. More compact with `11px` font size. Looks close to pre `0.6.0`.
- `auto`. This is the default. It automatically switches between the spacious and compact mode based on how large the window is. It also switches to `13px` and `14px` font size the wider the window gets.

![compact-11px](https://cloud.githubusercontent.com/assets/378023/7275098/e1cc4b72-e93c-11e4-9c75-35364ce4ba5c.png)

![spacious-12px](https://cloud.githubusercontent.com/assets/378023/7275101/e66d557c-e93c-11e4-8ef2-fb220595f810.png)

![spacious-14px](https://cloud.githubusercontent.com/assets/378023/7275106/eb070a88-e93c-11e4-84e1-97514a7cb0b6.png)

ps. It's still possible to override the font size in `styles.less`, no matter what layout mode is chosen. So you could have compact mode with a very large `16px` font size if preferred. Or spacious mode with a small font size.