### PR TITLE
Improve tabs

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -1,7 +1,7 @@
 @tab-border-size: 1px;
 @tab-border: @tab-border-size solid @tab-border-color;
-@tab-max-width: @ui-size*15;
-@tab-min-width: @ui-size*5;
+@tab-max-width: @ui-size*24;
+@tab-min-width: @ui-size*7.5; // icon + 3 characters
 @tab-padding: @ui-padding/2;
 @modified-icon-width: @ui-size*1.5;
 

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -1,9 +1,9 @@
 @tab-border-size: 1px;
 @tab-border: @tab-border-size solid @tab-border-color;
-@tab-max-width: @ui-size*16;
-@tab-min-width: @ui-size*7.5; // icon + 3 characters
-@tab-padding: @ui-padding/1.25;
-@modified-icon-width: @ui-size*1.25;
+@tab-max-width: @ui-size*24;
+@tab-min-width: @ui-size*6; // icon + 3 characters
+@tab-padding: @ui-padding/1.5;
+@modified-icon-width: @ui-size;
 
 .tab-bar {
   height: @ui-tab-height;
@@ -66,6 +66,12 @@
       position: relative;
       z-index: 1;
       text-align: center;
+      margin: 0 @tab-padding;
+      text-overflow: clip;
+      -webkit-mask: linear-gradient( to left, hsla(0,0%,0%,0), hsla(0,0%,0%,1) 1em) no-repeat;
+    }
+    &:hover .title {
+      -webkit-mask-position: -@modified-icon-width 0;
     }
 
 
@@ -92,8 +98,7 @@
         font-size: inherit;
       }
     }
-    &:hover .close-icon,
-    &.active .close-icon {
+    &:hover .close-icon {
       transform: scale(1);
       transition-duration: .16s;
     }
@@ -104,7 +109,7 @@
 
   .tab,
   .tab.active {
-    flex: 0 0 auto;
+    flex: 1;
   }
 
 
@@ -112,9 +117,9 @@
 
   .tab,
   .tab.active {
-    padding-right: @modified-icon-width;
+    padding-right: 0;
     .title {
-      padding: 0 @tab-padding;
+      padding: 0;
     }
   }
 
@@ -126,6 +131,17 @@
     &[data-type="TextEditor"] {
       color: @tab-text-color-editor;
     }
+  }
+
+  // Tab seperator ----------------------
+
+  .tab {
+    border-width: 0 0 0 1px;
+    border-image: linear-gradient(@tab-bar-background-color, @base-border-color 1em) 0 0 0 1 stretch;
+  }
+  .tab.active,
+  .tab.active + .tab {
+    border-image: linear-gradient(transparent, transparent) 0 0 0 1 stretch;
   }
 
 

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -1,7 +1,7 @@
 @tab-border-size: 1px;
 @tab-border: @tab-border-size solid @tab-border-color;
-@tab-max-width: @ui-size*24;
-@tab-min-width: @ui-size*6; // icon + 3 characters
+@tab-max-width: @ui-size*22;
+@tab-min-width: @ui-size*7; // icon + 5 characters
 @tab-padding: @ui-padding/1.5;
 @modified-icon-width: @ui-size;
 

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -1,9 +1,9 @@
 @tab-border-size: 1px;
 @tab-border: @tab-border-size solid @tab-border-color;
-@tab-max-width: @ui-size*24;
+@tab-max-width: @ui-size*16;
 @tab-min-width: @ui-size*7.5; // icon + 3 characters
-@tab-padding: @ui-padding/2;
-@modified-icon-width: @ui-size*1.5;
+@tab-padding: @ui-padding/1.25;
+@modified-icon-width: @ui-size*1.25;
 
 .tab-bar {
   height: @ui-tab-height;
@@ -75,7 +75,7 @@
       top: 0;
       right: 0;
       z-index: 1;
-      margin-right: @tab-padding*1.2;
+      padding: 0 @tab-padding/1.25;
       height: @ui-tab-height;
       line-height: @ui-tab-height;
       text-align: center;
@@ -102,11 +102,9 @@
 
   // Tab sizing ----------------------
 
-  .tab {
-    flex: 1;
-    &.active {
-      flex: 1 0 auto;
-    }
+  .tab,
+  .tab.active {
+    flex: 0 0 auto;
   }
 
 


### PR DESCRIPTION
This PR adds some improvements to the tabs. Closes #49 

- Let's you see at least icon + 4 characters
- Close icon is only visible on hover.
- Active tab stays the same width.
- Increases the max width a bit.
- All tabs have the same width. Should allow the "delaying tab size" feature for quick succession closing.
- Replaces the ellipsis with a fade out. This lets you see an extra 2-3 characters.

![tabs](https://cloud.githubusercontent.com/assets/378023/7152127/6250a932-e370-11e4-94e1-1c71ca9ef3c8.gif)