### PR TITLE
Allow all "Editors" to get dynamic tab styling.

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -51,7 +51,7 @@
       transition: opacity .16s;
       opacity: 0;
     }
-    &[data-type="TextEditor"]::after {
+    &[data-type$="Editor"]::after {
       background-color: @tab-background-color-editor;
       border-bottom-color: @tab-background-color-editor;
     }
@@ -128,7 +128,7 @@
 
   .tab.active {
     color: @tab-text-color-active;
-    &[data-type="TextEditor"] {
+    &[data-type$="Editor"] {
       color: @tab-text-color-editor;
     }
   }


### PR DESCRIPTION
Allow other "Editor"s to match the special dynamic table styling that's currently given to data-type=TextEditor.

https://discuss.atom.io/t/how-to-make-my-tabs-look-like-texteditor-tabs-in-the-new-one-themes/14995/4