### PR TITLE
Replace spinner

### DIFF
--- a/styles/progress.less
+++ b/styles/progress.less
@@ -1,35 +1,60 @@
 
 // Spinner ----------------------
 
-.loading-spinner(@size) {
-  width: @size;
-  height: @size;
-  display: block;
+@spinner-width: .1em;
+@spinner-offset: @spinner-width/2;
 
-  background-image: url(images/octocat-spinner-128.gif);
-  background-repeat: no-repeat;
-  background-size: cover;
+.loading {
+  position: relative;
+  display: block;
+  width: 1em;
+  height: 1em;
+  border: 2px solid @base-accent-color;
+  border-radius: 1em;
+
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    z-index: 10; // prevent sibling elements from getting their own layers
+    top: 50%;
+    left: 50%;
+    margin: -@spinner-offset 0 0 -@spinner-offset;
+    width: @spinner-width;
+    border-radius: inherit;
+
+    transform-origin: @spinner-offset @spinner-offset;
+    -webkit-animation: spinner-animation 1.2s infinite;
+    -webkit-animation-fill-mode: backwards;
+  }
+  &::before { //hour
+    height: .4em;
+    background-color: @base-accent-color;
+    -webkit-animation-delay: .24s;
+  }
+  &::after { // minutes
+    height: .5em;
+    background-color: lighten(@base-accent-color, 15%);
+  }
 
   &.inline-block {
     display: inline-block;
   }
 }
 
-.loading-spinner-large {
-  .loading-spinner(64px);
+@-webkit-keyframes spinner-animation {
+    0% { transform: scale(.6) rotate(180deg); transform-origin: @spinner-offset @spinner-offset;      -webkit-animation-timing-function: cubic-bezier(.85, .15, .9, .65); }
+   50% { transform: scale( 1) rotate(360deg); transform-origin: @spinner-offset @spinner-offset*-1.5; -webkit-animation-timing-function: cubic-bezier(.1, .35, .15, .85); }
+  100% { transform: scale(.6) rotate(540deg); transform-origin: @spinner-offset @spinner-offset; }
 }
 
-.loading-spinner-medium {
-  .loading-spinner(50px);
-}
+// Spinner sizes
+.loading-spinner-tiny   { font-size: 16px; border-width: 1px; }
+.loading-spinner-small  { font-size: 32px; }
+.loading-spinner-medium { font-size: 48px; }
+.loading-spinner-large  { font-size: 64px; }
 
-.loading-spinner-small {
-  .loading-spinner(32px);
-}
 
-.loading-spinner-tiny {
-  .loading-spinner(20px);
-}
 
 
 // Progress Bar ----------------------

--- a/styles/progress.less
+++ b/styles/progress.less
@@ -43,9 +43,9 @@
 }
 
 @-webkit-keyframes spinner-animation {
-    0% { transform: scale(.6) rotate(180deg); transform-origin: @spinner-offset @spinner-offset;      -webkit-animation-timing-function: cubic-bezier(.85, .15, .9, .65); }
-   50% { transform: scale( 1) rotate(360deg); transform-origin: @spinner-offset @spinner-offset*-1.5; -webkit-animation-timing-function: cubic-bezier(.1, .35, .15, .85); }
-  100% { transform: scale(.6) rotate(540deg); transform-origin: @spinner-offset @spinner-offset; }
+    0% { transform: scale(.6) rotate(180deg); -webkit-animation-timing-function: cubic-bezier(.85, .15, .9, .65); }
+   50% { transform: scale( 1) rotate(360deg); -webkit-animation-timing-function: cubic-bezier(.1, .35, .15, .85); }
+  100% { transform: scale(.6) rotate(540deg); }
 }
 
 // Spinner sizes

--- a/styles/progress.less
+++ b/styles/progress.less
@@ -1,39 +1,41 @@
 
 // Spinner ----------------------
 
-@spinner-width: .1em;
+@spinner-duration: 1.2s;
+@spinner-width: .2em;
 @spinner-offset: @spinner-width/2;
+@spinner-radius: .5em + @spinner-offset/2;
 
 .loading {
   position: relative;
   display: block;
   width: 1em;
   height: 1em;
-  border: 2px solid @base-accent-color;
   border-radius: 1em;
+  border: 2px solid @base-accent-color;
+  background: radial-gradient(@base-accent-color .1em, transparent .11em);
 
   &::before,
   &::after {
     content: "";
     position: absolute;
     z-index: 10; // prevent sibling elements from getting their own layers
-    top: 50%;
+    top: 0;
     left: 50%;
     margin: -@spinner-offset 0 0 -@spinner-offset;
     width: @spinner-width;
+    height: @spinner-width;
     border-radius: inherit;
 
-    transform-origin: @spinner-offset @spinner-offset;
-    -webkit-animation: spinner-animation 1.2s infinite;
+    transform-origin: @spinner-offset @spinner-radius;
+    -webkit-animation: spinner-animation @spinner-duration infinite;
     -webkit-animation-fill-mode: backwards;
   }
   &::before { //hour
-    height: .4em;
     background-color: @base-accent-color;
-    -webkit-animation-delay: .24s;
+    -webkit-animation-delay: @spinner-duration/2;
   }
   &::after { // minutes
-    height: .5em;
     background-color: lighten(@base-accent-color, 15%);
   }
 
@@ -43,9 +45,9 @@
 }
 
 @-webkit-keyframes spinner-animation {
-    0% { transform: scale(.6) rotate(180deg); -webkit-animation-timing-function: cubic-bezier(.85, .15, .9, .65); }
-   50% { transform: scale( 1) rotate(360deg); -webkit-animation-timing-function: cubic-bezier(.1, .35, .15, .85); }
-  100% { transform: scale(.6) rotate(540deg); }
+    0% { transform: scale(1) rotateZ(  0deg); -webkit-animation-timing-function: cubic-bezier(0, 0, .8, .2); }
+   50% { transform: scale(1) rotateZ(180deg); -webkit-animation-timing-function: cubic-bezier(.2, .8, 1, 1); }
+  100% { transform: scale(1) rotateZ(360deg); }
 }
 
 // Spinner sizes

--- a/styles/progress.less
+++ b/styles/progress.less
@@ -2,17 +2,12 @@
 // Spinner ----------------------
 
 @spinner-duration: 1.2s;
-@spinner-width: .2em;
-@spinner-offset: @spinner-width/2;
-@spinner-radius: .5em + @spinner-offset/2;
 
 .loading {
   position: relative;
   display: block;
   width: 1em;
   height: 1em;
-  border-radius: 1em;
-  border: 2px solid @base-accent-color;
   background: radial-gradient(@base-accent-color .1em, transparent .11em);
 
   &::before,
@@ -21,22 +16,21 @@
     position: absolute;
     z-index: 10; // prevent sibling elements from getting their own layers
     top: 0;
-    left: 50%;
-    margin: -@spinner-offset 0 0 -@spinner-offset;
-    width: @spinner-width;
-    height: @spinner-width;
-    border-radius: inherit;
-
-    transform-origin: @spinner-offset @spinner-radius;
+    left: 0;
+    border-radius: 1em;
+    width: inherit;
+    height: inherit;
+    border-radius: 1em;
+    border: 2px solid;
     -webkit-animation: spinner-animation @spinner-duration infinite;
     -webkit-animation-fill-mode: backwards;
   }
-  &::before { //hour
-    background-color: @base-accent-color;
-    -webkit-animation-delay: @spinner-duration/2;
+  &::before {
+    border-color: @base-accent-color transparent transparent transparent;
   }
-  &::after { // minutes
-    background-color: lighten(@base-accent-color, 15%);
+  &::after {
+    border-color: transparent lighten(@base-accent-color, 15%) transparent transparent;
+    -webkit-animation-delay: @spinner-duration/2;
   }
 
   &.inline-block {
@@ -45,13 +39,13 @@
 }
 
 @-webkit-keyframes spinner-animation {
-    0% { transform: scale(1) rotateZ(  0deg); -webkit-animation-timing-function: cubic-bezier(0, 0, .8, .2); }
-   50% { transform: scale(1) rotateZ(180deg); -webkit-animation-timing-function: cubic-bezier(.2, .8, 1, 1); }
-  100% { transform: scale(1) rotateZ(360deg); }
+    0% { transform: rotateZ(  0deg); -webkit-animation-timing-function: cubic-bezier(0, 0, .8, .2); }
+   50% { transform: rotateZ(180deg); -webkit-animation-timing-function: cubic-bezier(.2, .8, 1, 1); }
+  100% { transform: rotateZ(360deg); }
 }
 
 // Spinner sizes
-.loading-spinner-tiny   { font-size: 16px; border-width: 1px; }
+.loading-spinner-tiny   { font-size: 16px; &::before, &::after { border-width: 1px; } }
 .loading-spinner-small  { font-size: 32px; }
 .loading-spinner-medium { font-size: 48px; }
 .loading-spinner-large  { font-size: 64px; }


### PR DESCRIPTION
Before:

![spinners-before](https://cloud.githubusercontent.com/assets/378023/9288455/05933822-4383-11e5-811f-60d9c1e78c54.gif)

After:

![spinners-after](https://cloud.githubusercontent.com/assets/378023/9288458/0dcbfb8c-4383-11e5-930a-d15bc1ad86f7.gif)


Benefits:

- Doesn't need repaints, uses HWA layers
- Colors match better the theme. Especially the white gif was was hard to see in One light.
- The gif looked a bit pixelated

Although R.I.P. :octocat: :cry: