### PR TITLE
Only have shadow on tabs on hover

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -69,12 +69,12 @@
       text-align: center;
       margin: 0 @tab-padding;
       text-overflow: clip;
-      // To use a mask and keep sub-pixel AA: Also add an opaque bg + HWA layer
-      -webkit-mask: linear-gradient( to left, hsla(0,0%,0%,0), hsla(0,0%,0%,1) 1em) no-repeat;
       background-color: @tab-background-color;
       backface-visibility: hidden;
     }
     &:hover .title {
+      // To use a mask and keep sub-pixel AA: Also add an opaque bg + HWA layer
+      -webkit-mask: linear-gradient( to left, hsla(0,0%,0%,0), hsla(0,0%,0%,1) 1em) no-repeat;
       -webkit-mask-position: -@modified-icon-width 0;
     }
     &.active .title {


### PR DESCRIPTION
This is driving me crazy that the end of all the file names are partially occluded.

Before:
<img width="319" alt="screen shot 2015-09-01 at 2 22 26 pm" src="https://cloud.githubusercontent.com/assets/197597/9616921/5c726d90-50b5-11e5-9eec-5255750e3ab4.png">

After:
<img width="318" alt="screen shot 2015-09-01 at 2 22 58 pm" src="https://cloud.githubusercontent.com/assets/197597/9616922/5c779158-50b5-11e5-934c-149210c92e6e.png">

It works the same when you mouse over