### PR TITLE
:apple: Move tab close icon to the left side

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -272,3 +272,20 @@ atom-pane.active .tab.active:before {
     }
   }
 }
+
+// Swap close button on OSX --------------
+
+.platform-darwin {
+  .tab-bar .tab .close-icon {
+    left: 0;
+    right: auto;
+  }
+  .tab-bar .tab:hover .title {
+    -webkit-mask: linear-gradient( to right, hsla(0,0%,0%,0), hsla(0,0%,0%,1) 1em) no-repeat;
+    -webkit-mask-position: 1em 0;
+    // Remove file icon on :hover
+    &::before {
+        content: "";
+    }
+  }
+}


### PR DESCRIPTION
Move tab close icon to the left side as per OSX Human Inteface Guidelines.
Fixes #93
