### PR TITLE
Use system font (more robustly)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "repository": "https://github.com/atom/one-dark-ui",
   "main": "lib/main",
   "engines": {
-    "atom": ">0.40.0"
+    "atom": ">1.0.11"
   },
   "devDependencies": {
     "coffeelint": "^1.9.7"

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -130,6 +130,10 @@
 @tab-height:              30px;
 
 
+// Font -----------------
+@font-family: 'system';
+
+
 
 
 


### PR DESCRIPTION
Refs https://github.com/atom/atom/pull/8778

This PR re-specifies a `@font-family`, but this time using the new `system` keyword.