### PR TITLE
Fix tab bottom border

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -65,13 +65,15 @@
 
     .title {
       position: relative;
-      bottom: @tab-border-size;
+      height: inherit;
       text-align: center;
       margin: 0 @tab-padding;
+      border-bottom: @tab-border-size solid transparent;
       text-overflow: clip;
       // To use a mask and keep sub-pixel AA: Also add an opaque bg + HWA layer
       -webkit-mask: linear-gradient( to left, hsla(0,0%,0%,0), hsla(0,0%,0%,1) 1em) no-repeat;
       background-color: @tab-background-color;
+      background-clip: content-box;
       backface-visibility: hidden;
     }
     &:hover .title {
@@ -178,14 +180,10 @@
   // Dragging ----------------------
 
   .tab.is-dragging {
+    opacity: .5;
     .close-icon,
     &:before {
       visibility: hidden;
-    }
-    &::after {
-      background: darken(@tab-background-color, 6%);
-      border-color: transparent;
-      opacity: .5;
     }
   }
 


### PR DESCRIPTION
The bottom border was cut off in the center.

Before

![img](https://cloud.githubusercontent.com/assets/378023/11014080/96d22572-856a-11e5-82f4-ab33faaef20e.png)

After

![img](https://cloud.githubusercontent.com/assets/378023/11014085/b415e024-856a-11e5-9e34-e3d83bd1ecbb.png)

Fixes https://github.com/atom/one-dark-ui/issues/106