### PR TITLE
Remove transform that was preventing text from rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "one-dark-ui",
   "theme": "ui",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Atom One dark UI theme",
   "keywords": [
     "dark",

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -73,8 +73,16 @@
   width: 2px;
   background: @base-accent-color;
   opacity: 0;
-  // transform: scaleY(0);
+}
+
+ol.tree-view::before {
+  transform: scaleY(0);
   transition: opacity .16s, transform .16s cubic-bezier(.80, 0, .90, .53);
+}
+
+ol.tree-view:focus::before {
+  transform: scaleY(1);
+  transition: opacity .16s, transform .32s cubic-bezier(0,.6,.2,1);
 }
 
 [data-show-on-right-side="true"] .tree-view::before {
@@ -84,6 +92,4 @@
 
 .tree-view:focus::before {
   opacity: 1;
-  transform: scaleY(1);
-  transition: opacity .16s, transform .32s cubic-bezier(0,.6,.2,1);
 }

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -73,7 +73,7 @@
   width: 2px;
   background: @base-accent-color;
   opacity: 0;
-  transform: scaleY(0);
+  // transform: scaleY(0);
   transition: opacity .16s, transform .16s cubic-bezier(.80, 0, .90, .53);
 }
 

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -73,16 +73,8 @@
   width: 2px;
   background: @base-accent-color;
   opacity: 0;
-}
-
-ol.tree-view::before {
-  transform: scaleY(0);
+  // transform: scaleY(0);
   transition: opacity .16s, transform .16s cubic-bezier(.80, 0, .90, .53);
-}
-
-ol.tree-view:focus::before {
-  transform: scaleY(1);
-  transition: opacity .16s, transform .32s cubic-bezier(0,.6,.2,1);
 }
 
 [data-show-on-right-side="true"] .tree-view::before {
@@ -92,4 +84,6 @@ ol.tree-view:focus::before {
 
 .tree-view:focus::before {
   opacity: 1;
+  transform: scaleY(1);
+  transition: opacity .16s, transform .32s cubic-bezier(0,.6,.2,1);
 }

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -73,8 +73,6 @@
   width: 2px;
   background: @base-accent-color;
   opacity: 0;
-  // transform: scaleY(0);
-  transition: opacity .16s, transform .16s cubic-bezier(.80, 0, .90, .53);
 }
 
 [data-show-on-right-side="true"] .tree-view::before {
@@ -84,6 +82,4 @@
 
 .tree-view:focus::before {
   opacity: 1;
-  transform: scaleY(1);
-  transition: opacity .16s, transform .32s cubic-bezier(0,.6,.2,1);
 }


### PR DESCRIPTION
With very long lines the texts would stop rendering after a certain point.
Before:
![image](https://cloud.githubusercontent.com/assets/7707452/11605253/f3cbb1cc-9b4e-11e5-819e-7756809ebb0c.png)

I did some trawling through the history and found that commit 25de9953d150b2a4c11631f5669955d349edfb66 caused the issue.

I'm not quite sure what the transform is for. So I may be breaking a use case I'm unaware of
After:
![image](https://cloud.githubusercontent.com/assets/7707452/11605255/f67abbca-9b4e-11e5-8548-15c8b59438ca.png)