### PR TITLE
Keep tree view highlight next to first Project Folder when scrolling

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -63,7 +63,7 @@
 
 .tree-view::before {
   content: "";
-  position: fixed;
+  position: absolute;
   pointer-events: none;
   z-index: 1;
   margin-top: @ui-padding-pane;

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -18,7 +18,7 @@
 
 .ui-saturation() when (@ui-s-h <=  80) { @ui-saturation: min(@ui-s-s,  5%); } // minimize saturation for brown
 .ui-saturation() when (@ui-s-h >   80) and (@ui-s-h <  160) { @ui-saturation: min(@ui-s-s, 12%); } // reduce saturation for green
-.ui-saturation() when (@ui-s-h >= 160) and (@ui-s-l <  @ui-inv) { @ui-saturation: min(@ui-s-s, 48%); } // limit max saturaiotn for very dark backgrounds
+.ui-saturation() when (@ui-s-h >= 160) and (@ui-s-l <  @ui-inv) { @ui-saturation: min(@ui-s-s, 48%); } // limit max saturation for very dark backgrounds
 .ui-saturation() when (@ui-s-h >= 160) and (@ui-s-l >= @ui-inv) { @ui-saturation: @ui-s-s; }
 .ui-saturation();
 


### PR DESCRIPTION
Change the position attribute from fixed to absolute to keep the highlight next to the first Project Folder when scrolling in the tree view.