### PR TITLE
Use auto-size for tabs in compact mode

### DIFF
--- a/styles/config.less
+++ b/styles/config.less
@@ -77,6 +77,21 @@ html { font-size: @font-size; }
       border-right: none;
       box-shadow: inset 0 1px 1px hsla(0,0%,100,.06), 1px 0 0 @base-border-color;
     }
+
+    // auto-size tabs
+    .tab,
+    .tab.active {
+      flex: 0 0 auto;
+      min-width: @ui-tab-height;
+    }
+
+    .tab .title {
+      -webkit-mask: none;
+    }
+    .tab:hover .title {
+      -webkit-mask: linear-gradient( to left, hsla(0,0%,0%,0), hsla(0,0%,0%,1) 1em) no-repeat;
+      -webkit-mask-position: -@modified-icon-width 0;
+    }
   }
 
 


### PR DESCRIPTION
This PR makes the tabs only use the width they need when in "compact mode".

![tabs](https://cloud.githubusercontent.com/assets/378023/13005262/199b4fd8-d1c4-11e5-9f0c-99673cf5cc7e.gif)

- closes #120
- closes #94