### PR TITLE
Hide tooltips behind panels

### DIFF
--- a/styles/atom.less
+++ b/styles/atom.less
@@ -9,8 +9,11 @@ html {
 atom-workspace {
 	background-color: @app-background-color;
 
-	atom-panel-container.left:empty {
-		padding-left: @ui-padding-pane;
+	atom-panel-container {
+		z-index: 5;
+		&.left:empty {
+			padding-left: @ui-padding-pane;
+		}
 	}
 
 }


### PR DESCRIPTION
Before
<img width="753" alt="screen shot 2016-03-18 at 11 04 19 am" src="https://cloud.githubusercontent.com/assets/4278113/13887648/2bb1cb06-ecfa-11e5-9f10-ed36248712e1.png">

After
<img width="775" alt="screen shot 2016-03-18 at 11 04 10 am" src="https://cloud.githubusercontent.com/assets/4278113/13887653/332cab30-ecfa-11e5-8040-18312217f0b1.png">

Fixes https://github.com/AtomLinter/linter-ui-default/issues/51