### PR TITLE
Add tree-view bottom border

### DIFF
--- a/styles/config.less
+++ b/styles/config.less
@@ -85,6 +85,11 @@ html { font-size: @font-size; }
     border-left: 1px solid @base-border-color;
   }
 
+  .tree-view-scroller {
+    border-image: none;
+    border-bottom: 1px solid @base-border-color;
+  }
+
   .tree-view::before {
     margin-top: 0;
   }

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -33,6 +33,11 @@
   }
 }
 
+.tree-view-scroller {
+  border-width: 0 0 1px 0;
+  border-image: linear-gradient(to right, @tree-view-background-color @component-padding, @base-border-color @component-padding * 5) 0 0 1 0 stretch;
+}
+
 // Variable height, based on ems
 .list-group li:not(.list-nested-item),
 .list-tree li:not(.list-nested-item),


### PR DESCRIPTION
Now that the status-bar spans full-width, it's not clear where the tree-view ends.

Ref: https://github.com/atom/one-light-ui/issues/55