### PR TITLE
Add mask to modified dot

### DIFF
--- a/styles/config.less
+++ b/styles/config.less
@@ -137,11 +137,21 @@ html { font-size: @font-size; }
     min-width: @ui-tab-height;
   }
 
+  .tab .close-icon {
+    padding-left: .4em;
+    padding-right: .4em;
+  }
+
   .tab .title {
     -webkit-mask: none;
   }
   .tab:hover .title {
     -webkit-mask: linear-gradient( to left, hsla(0,0%,0%,0), hsla(0,0%,0%,1) 1em) no-repeat;
-    -webkit-mask-position: -@modified-icon-width 0;
+    -webkit-mask-position: -@modified-icon-width*.6 0;
+  }
+
+  .tab.modified .title {
+    -webkit-mask: linear-gradient( to left, hsla(0,0%,0%,0), hsla(0,0%,0%,1) 1em) no-repeat;
+    -webkit-mask-position: -@modified-icon-width*.4 0;
   }
 }


### PR DESCRIPTION
Before :see_no_evil: | After :monkey_face:
--- | ---
![screen shot 2016-06-09 at 5 00 30 pm](https://cloud.githubusercontent.com/assets/378023/15922651/d1257a38-2e63-11e6-8bf7-b2e273ae3a05.png) | ![screen shot 2016-06-09 at 4 57 55 pm](https://cloud.githubusercontent.com/assets/378023/15922656/d79c7c72-2e63-11e6-8062-de7aec62fb2d.png)

This also makes the dot and close-icon a bit less wide, to minimize accidental clicks.

Fixes https://github.com/atom/one-light-ui/issues/59