### PR TITLE
[WIP] Accent color picker

### DIFF
--- a/index.less
+++ b/index.less
@@ -29,3 +29,5 @@
 @import "styles/packages";
 @import "styles/core";
 @import "styles/config";
+
+@import "styles/ui-variables-custom";

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,6 +2,9 @@ root = document.documentElement
 
 module.exports =
   activate: (state) ->
+    atom.config.observe 'one-dark-ui.accentColor', (value) ->
+      setAccentColor(value)
+
     atom.config.observe 'one-dark-ui.fontSize', (value) ->
       setFontSize(value)
 
@@ -12,9 +15,19 @@ module.exports =
       setTabSizing(value)
 
   deactivate: ->
+    unsetAccentColor()
     unsetFontSize()
     unsetLayoutMode()
     unsetTabSizing()
+
+
+# Accent Color -----------------------
+setAccentColor = (accentColor) ->
+  unsetAccentColor()
+  root.style.setProperty('--accent-color', accentColor.toHexString())
+
+unsetAccentColor = ->
+  root.style.removeProperty('--accent-color')
 
 # Font Size -----------------------
 setFontSize = (currentFontSize) ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -5,6 +5,9 @@ module.exports =
     atom.config.observe 'one-dark-ui.accentColor', (value) ->
       setAccentColor(value)
 
+    atom.config.observe 'one-dark-ui.autoAccentColor', (value) ->
+      setAutoAccentColor(value)
+
     atom.config.observe 'one-dark-ui.fontSize', (value) ->
       setFontSize(value)
 
@@ -16,6 +19,7 @@ module.exports =
 
   deactivate: ->
     unsetAccentColor()
+    unsetAutoAccentColor()
     unsetFontSize()
     unsetLayoutMode()
     unsetTabSizing()
@@ -23,11 +27,23 @@ module.exports =
 
 # Accent Color -----------------------
 setAccentColor = (accentColor) ->
-  unsetAccentColor()
+  root.style.removeProperty('--accent-color') # prevents adding endless properties
   root.style.setProperty('--accent-color', accentColor.toHexString())
 
 unsetAccentColor = ->
   root.style.removeProperty('--accent-color')
+
+# Auto Accent Color -----------------------
+setAutoAccentColor = (autoAccentColor) ->
+  if autoAccentColor
+    document.body.classList.add('use-auto-accent-color')
+  else
+    unsetAutoAccentColor()
+
+unsetAutoAccentColor = ->
+  document.body.classList.remove('use-auto-accent-color')
+
+
 
 # Font Size -----------------------
 setFontSize = (currentFontSize) ->

--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
     "coffeelint": "^1.9.7"
   },
   "configSchema": {
+    "accentColor": {
+      "title": "Accent Color",
+      "description": "Change the accent color of this theme.",
+      "type": "color",
+      "default": "cornflowerblue"
+    },
     "fontSize": {
       "title": "Font Size",
       "description": "Change the UI font size. Needs to be between 8 and 20. In Auto mode, the Font Size will automatically change based on the window size.",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
       "type": "color",
       "default": "cornflowerblue"
     },
+    "autoAccentColor": {
+      "title": "Auto Accent Color",
+      "description": "If this is enabled, the accent color will be automatically set based on the syntax theme.",
+      "type": "boolean",
+      "default": true
+    },
     "fontSize": {
       "title": "Font Size",
       "description": "Change the UI font size. Needs to be between 8 and 20. In Auto mode, the Font Size will automatically change based on the window size.",

--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -25,11 +25,11 @@
     box-shadow: none;
   }
   &.selected {
-    background: @selected-color;
+    background: var(--accent-color);
   }
   &.selected:focus,
   &.selected:hover {
-    background: lighten(@selected-color, 2%);
+    background: var(--accent-color);
   }
 }
 

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -23,7 +23,7 @@ atom-text-editor[mini] {
       background-color: @input-selection-color;
     }
     .cursor {
-      border-color: @base-accent-color;
+      border-color: var(--accent-color);
       border-width: 2px;
     }
   }

--- a/styles/progress.less
+++ b/styles/progress.less
@@ -9,7 +9,7 @@
   width: 1em;
   height: 1em;
   font-size: @size;
-  background: radial-gradient(@base-accent-color .1em, transparent .11em);
+  background: radial-gradient(var(--accent-color) .1em, transparent .11em);
 
   &::before,
   &::after {
@@ -27,10 +27,10 @@
     -webkit-animation-fill-mode: backwards;
   }
   &::before {
-    border-color: @base-accent-color transparent transparent transparent;
+    border-color: var(--accent-color) transparent transparent transparent;
   }
   &::after {
-    border-color: transparent lighten(@base-accent-color, 15%) transparent transparent;
+    border-color: transparent var(--accent-color) transparent transparent;
     -webkit-animation-delay: @spinner-duration/2;
   }
 
@@ -72,7 +72,7 @@ progress {
 
   &::-webkit-progress-value {
     border-radius: @component-border-radius;
-    background-color: @progress-background-color;
+    background-color: var(--accent-color);
   }
 
   // Is buffering (when no value is set)

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -156,9 +156,13 @@
   // Modified ----------------------
   .tab.modified {
     .close-icon {
-      color: @text-color-info;
       border: none;
       border-bottom: @tab-border-size solid transparent;
+      &::before { color: inherit; }
+    }
+    &:hover .close-icon,
+    .close-icon {
+      color: var(--accent-color);
     }
     &:not(:hover) .close-icon {
       right: 0;
@@ -190,7 +194,7 @@
   .placeholder {
     margin: 0;
     height: @ui-tab-height;
-    background: @base-accent-color;
+    background: var(--accent-color);
     pointer-events: none;
     &:after {
       top: @ui-tab-height/2;
@@ -199,7 +203,7 @@
       margin: -5px 0 0 0;
       border-radius: 0;
       border: 5px solid;
-      border-color: transparent transparent transparent @base-accent-color;
+      border-color: transparent transparent transparent var(--accent-color);
       background: transparent;
     }
 
@@ -208,7 +212,7 @@
 
       &:after {
         margin-left: -10px;
-        border-color: transparent @base-accent-color transparent transparent;
+        border-color: transparent var(--accent-color) transparent transparent;
       }
     }
   }

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -228,7 +228,7 @@
   width: 2px;
   border-top-left-radius: inherit;
   border-radius: @component-border-radius 0;
-  background: @base-accent-color;
+  background: var(--accent-color);
   opacity: 0;
   transition: opacity .16s;
 

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -75,7 +75,7 @@
   margin-left: -@component-icon-padding;
   height: @ui-tab-height;
   width: 2px;
-  background: @base-accent-color;
+  background: var(--accent-color);
   opacity: 0;
   transition: opacity .16s;
 }

--- a/styles/ui-mixins.less
+++ b/styles/ui-mixins.less
@@ -32,6 +32,7 @@
 
 .focus() {
   outline: none;
-  border-color: @base-accent-color;
-  box-shadow: 0 0 0 1px @base-accent-color;
+  color: var(--accent-color);
+  border-color: currentColor;;
+  box-shadow: 0 0 0 1px currentColor;
 }

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -1,0 +1,8 @@
+
+// Custom properties (CSS variables)
+// These can be changed in styles.less
+// ----------------------------------------------
+
+:root {
+  --accent-color: @base-accent-color;
+}

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -3,6 +3,33 @@
 // These can be changed in styles.less
 // ----------------------------------------------
 
-:root {
+
+// Accent Color
+
+.use-auto-accent-color {
   --accent-color: @base-accent-color;
+
+  // disable color picker if auto is on
+  // this only works if there is just a single color picker, so far so good
+  .settings-view .color {
+    opacity: .2;
+    pointer-events: none;
+  }
+}
+
+label[for="one-dark-ui.autoAccentColor"] {
+  margin-left: 2.5em;
+
+  & + .setting-description {
+    margin-left: 2.8em;
+  }
+}
+
+input[id="one-dark-ui.autoAccentColor"] {
+  margin-right: 1em;
+}
+
+// subtle accent color when window is blurred
+.is-blurred {
+  --accent-color: @text-color-subtle;
 }

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -193,8 +193,8 @@
 @tab-text-color-editor:             contrast(@ui-syntax-color, darken(@ui-syntax-color, 50%), @text-color-highlight );
 @tab-background-color-editor:       @ui-syntax-color;
 
-@tooltip-background-color:          @base-accent-color;
-@tooltip-text-color:                contrast(@tooltip-background-color, white, hsl(@ui-hue,100%,10%), 40% );
+@tooltip-background-color:          var(--accent-color);
+@tooltip-text-color:                contrast(@base-accent-color, white, hsl(@ui-hue,100%,10%), 40% );
 @tooltip-text-key-color:            @tooltip-background-color;
 @tooltip-background-key-color:      @tooltip-text-color;
 


### PR DESCRIPTION
This adds a color picker to the theme settings to change the accent color. Used on the tab marker, but also other places like the tooltips:

![colors](https://cloud.githubusercontent.com/assets/378023/16027565/d363b6f0-3211-11e6-8de4-7941697759d9.gif)

It uses the CSS custom properties [recently added to Electron](http://electron.atom.io/blog/2016/03/25/electron-37#css-custom-properties) (currently in Atom Beta `1.9`). So updating colors is super fast and no need to recompile the Less files. Yayyy..

Buuuut... as seen in the above gif, currently CSS doesn't support color manipulation like darken/lighten or checking contrast like you can do in Less. So if you pick a very light color, you can't read the text in the tooltips. Some options:

1. Not worry about it. It's up to the user to choose a color that works. But not everyone will open the Styleguide to make sure everything looks ok.
2. Just use the accent color for stuff that has no next, like the tab marker. That would be nice initially, but it just makes it look strange, having two different accent colors. Especially if they are close, but not the same.
3. Don't show a color picker but instead a dropdown with a few predefined colors.
4. Maybe use some JS color library that makes sure the text color has enough contrast. It would update `--accent-background-color` **and** `--accent-color`.

I guess either 3 or 4.