### PR TITLE
Accent color

### DIFF
--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -34,7 +34,7 @@
 }
 
 .btn-variant (@color) {
-  @_text-color: contrast(@color, hsl(0,0%,25%), white, 70% );
+  @_text-color: contrast(@color, white, hsl(0,0%,20%), 33% );
   .btn-default(
     @color,
     lighten(@color, 3%),

--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -74,7 +74,7 @@
 }
 
 .btn.btn-primary {
-  .btn-variant(@base-accent-color);
+  .btn-variant(@accent-color);
 }
 .btn.btn-info {
   .btn-variant(@background-color-info);

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -23,7 +23,7 @@ atom-text-editor[mini] {
       background-color: @input-selection-color;
     }
     .cursor {
-      border-color: @base-accent-color;
+      border-color: @accent-color;
       border-width: 2px;
     }
   }

--- a/styles/progress.less
+++ b/styles/progress.less
@@ -9,7 +9,7 @@
   width: 1em;
   height: 1em;
   font-size: @size;
-  background: radial-gradient(@base-accent-color .1em, transparent .11em);
+  background: radial-gradient(@accent-color .1em, transparent .11em);
 
   &::before,
   &::after {
@@ -27,10 +27,10 @@
     -webkit-animation-fill-mode: backwards;
   }
   &::before {
-    border-color: @base-accent-color transparent transparent transparent;
+    border-color: @accent-color transparent transparent transparent;
   }
   &::after {
-    border-color: transparent lighten(@base-accent-color, 15%) transparent transparent;
+    border-color: transparent lighten(@accent-color, 15%) transparent transparent;
     -webkit-animation-delay: @spinner-duration/2;
   }
 

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -117,6 +117,10 @@
 		font-size: .75em;
 	}
 
+	.install-button {
+		.btn-variant(@accent-color);
+	}
+
 	.search-container .btn {
 		font-size: @ui-input-size;
 	}

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -121,6 +121,18 @@
 		.btn-variant(@accent-color);
 	}
 
+	input[type="checkbox"] {
+		background-color: @background-color-selected;
+		&:active,
+		&:checked {
+			background-color: @accent-color;
+		}
+		&:before,
+		&:after {
+			background-color: @accent-text-on-bg-color;
+		}
+	}
+
 	.search-container .btn {
 		font-size: @ui-input-size;
 	}

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -99,11 +99,11 @@
       transform: scale(0);
       transition: transform .08s;
       &:hover {
-        color: @base-accent-text-on-bg-color;
-        background-color: @base-accent-color;
+        color: @accent-text-on-bg-color;
+        background-color: @accent-color;
       }
       &:active {
-        background-color: fade(@base-accent-color, 50%);
+        background-color: fade(@accent-color, 50%);
       }
       &::before {
         content: "\f05d"; // plus icon has a smaller weight
@@ -169,9 +169,9 @@
   // Modified ----------------------
   .tab.modified {
     &:hover .close-icon {
-      color: @base-accent-text-color;
+      color: @accent-text-color;
       &:hover {
-        color: @base-accent-text-on-bg-color;
+        color: @accent-text-on-bg-color;
       }
     }
     &:not(:hover) .close-icon {
@@ -180,7 +180,7 @@
       width: 1.5em;
       height: 1.5em;
       line-height: 1.5;
-      color: @base-accent-text-color;
+      color: @accent-text-color;
       border: none;
       transform: scale(1);
       &::before {
@@ -204,7 +204,7 @@
   .placeholder {
     margin: 0;
     height: @ui-tab-height;
-    background: @base-accent-color;
+    background: @accent-color;
     pointer-events: none;
     &:after {
       top: @ui-tab-height/2;
@@ -213,7 +213,7 @@
       margin: -5px 0 0 0;
       border-radius: 0;
       border: 5px solid;
-      border-color: transparent transparent transparent @base-accent-color;
+      border-color: transparent transparent transparent @accent-color;
       background: transparent;
     }
 
@@ -222,7 +222,7 @@
 
       &:after {
         margin-left: -10px;
-        border-color: transparent @base-accent-color transparent transparent;
+        border-color: transparent @accent-color transparent transparent;
       }
     }
   }
@@ -242,7 +242,7 @@
   width: 2px;
   border-top-left-radius: inherit;
   border-radius: @component-border-radius 0;
-  background: @base-accent-color;
+  background: @accent-color;
   opacity: 0;
   transition: opacity .16s;
 

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -75,7 +75,7 @@
   margin-left: -@component-icon-padding;
   height: @ui-tab-height;
   width: 2px;
-  background: @base-accent-color;
+  background: @accent-color;
   opacity: 0;
   transition: opacity .16s;
 }

--- a/styles/ui-mixins.less
+++ b/styles/ui-mixins.less
@@ -32,6 +32,6 @@
 
 .focus() {
   outline: none;
-  border-color: @base-accent-color;
-  box-shadow: 0 0 0 1px @base-accent-color;
+  border-color: @accent-color;
+  box-shadow: 0 0 0 1px @accent-color;
 }

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -63,9 +63,9 @@
 
 
 // Base Accent (Custom) -----------------
-@base-accent-color:            hsl(@ui-hue, 100%, 66%);
-@base-accent-text-color:       lighten(@base-accent-color, 6%); // A bit lighter when used for smaller things
-@base-accent-text-on-bg-color: contrast(@base-accent-color, white, hsl(@ui-hue,100%,10%), 33% );
+@accent-color:            hsl(@ui-hue, 100%, 66%);
+@accent-text-color:       lighten(@accent-color, 6%); // A bit lighter when used for smaller things
+@accent-text-on-bg-color: contrast(@accent-color, white, hsl(@ui-hue,100%,10%), 33% );
 
 
 // Components (Custom) -----------------
@@ -74,7 +74,7 @@
 @button-text-color-selected:        contrast(@button-background-color-selected, white, hsl(@ui-hue,100%,10%), 40% );
 @button-border-color-selected:      @base-border-color;
 
-@checkbox-background-color:         fade(@base-accent-color, 33%);
+@checkbox-background-color:         fade(@accent-color, 33%);
 
 @input-background-color-focus:      fadein(@input-background-color, 6%);
 @input-selection-color:             darken(@background-color-selected, 6%);
@@ -85,7 +85,7 @@
 
 @overlay-backdrop-color:            hsla(@ui-hue,@ui-saturation,5%,.5);
 
-@progress-background-color:         @base-accent-color;
+@progress-background-color:         @accent-color;
 
 @scrollbar-color:                   @level-1-color;
 @scrollbar-background-color:        @level-3-color; // replaced `transparent` with a solid color to test https://github.com/atom/one-light-ui/issues/4
@@ -98,7 +98,7 @@
 @tab-text-color-editor:             contrast(@ui-syntax-color, darken(@ui-syntax-color, 50%), @text-color-highlight );
 @tab-background-color-editor:       @ui-syntax-color;
 
-@tooltip-background-color:          @base-accent-color;
+@tooltip-background-color:          @accent-color;
 @tooltip-text-color:                contrast(@tooltip-background-color, white, hsl(@ui-hue,100%,10%), 40% );
 @tooltip-text-key-color:            @tooltip-background-color;
 @tooltip-background-key-color:      @tooltip-text-color;

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -62,7 +62,7 @@
 @level-3-color: darken(@base-background-color, 3%);
 
 
-// Base Accent (Custom) -----------------
+// Accent (Custom) -----------------
 @accent-color:            hsl(@ui-hue, 100%, 66%);
 @accent-text-color:       lighten(@accent-color, 6%); // A bit lighter when used for smaller things
 @accent-text-on-bg-color: contrast(@accent-color, white, hsl(@ui-hue,100%,10%), 33% );
@@ -99,7 +99,7 @@
 @tab-background-color-editor:       @ui-syntax-color;
 
 @tooltip-background-color:          @accent-color;
-@tooltip-text-color:                contrast(@tooltip-background-color, white, hsl(@ui-hue,100%,10%), 40% );
+@tooltip-text-color:                @accent-text-on-bg-color;
 @tooltip-text-key-color:            @tooltip-background-color;
 @tooltip-background-key-color:      @tooltip-text-color;
 

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -71,7 +71,7 @@
 // Components (Custom) -----------------
 @badge-background-color:            lighten(@background-color-highlight, 6%);
 
-@button-text-color-selected:        contrast(@button-background-color-selected, white, hsl(@ui-hue,100%,10%), 40% );
+@button-text-color-selected:        @accent-text-on-bg-color;
 @button-border-color-selected:      @base-border-color;
 
 @checkbox-background-color:         fade(@accent-color, 33%);

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -60,7 +60,7 @@
 
 @button-background-color:          @level-1-color;
 @button-background-color-hover:    lighten(@button-background-color, 2%);
-@button-background-color-selected: @base-accent-color;
+@button-background-color-selected: @accent-color;
 @button-border-color:              @base-border-color;
 
 @tab-bar-background-color:         @level-3-color;


### PR DESCRIPTION
This refactors some styles around the "accent color".

Additionally, the accent color gets also used for:

- For the install buttons in the settings. So it matches the "Update all" button.
- The checkboxes

#### Before
![screen shot 2016-06-24 at 11 48 08 am](https://cloud.githubusercontent.com/assets/378023/16326443/928950f2-3a01-11e6-9555-0ac7913be622.png)

#### After
![screen shot 2016-06-24 at 11 45 58 am](https://cloud.githubusercontent.com/assets/378023/16326450/9b341912-3a01-11e6-8b40-76d3df850ee4.png)
![screen shot 2016-06-24 at 11 46 27 am](https://cloud.githubusercontent.com/assets/378023/16326451/9b34c772-3a01-11e6-8054-c694199a3826.png)
![screen shot 2016-06-24 at 11 47 06 am](https://cloud.githubusercontent.com/assets/378023/16326452/9b367112-3a01-11e6-8e0f-0a85779a109e.png)
