### PR TITLE
List group: maintain consistent size regardless of active icon presence

### DIFF
--- a/styles/lists.less
+++ b/styles/lists.less
@@ -84,6 +84,7 @@
       left: auto; right: auto;
       height: @active-icon-size;
       width: @active-icon-size;
+      font-size: @active-icon-size;
     }
     > li:not(.active):before {
       margin-right: @ui-padding-icon;


### PR DESCRIPTION
This is the same change as atom/one-light-ui#73, but for the Dark UI theme.