### PR TITLE
Stop using shadow DOM selectors

### DIFF
--- a/styles/atom.less
+++ b/styles/atom.less
@@ -14,46 +14,46 @@ atom-workspace {
 // Scrollbars ------------------------------------
 
 .scrollbars-visible-always {
-	/deep/ ::-webkit-scrollbar {
+	::-webkit-scrollbar {
 		width: 10px;
 		height: 10px;
 	}
 
-	/deep/ ::-webkit-scrollbar-track {
+	::-webkit-scrollbar-track {
 		background: @scrollbar-background-color;
 	}
 
-	/deep/ ::-webkit-scrollbar-thumb {
+	::-webkit-scrollbar-thumb {
 		border-radius: 5px;
 		border: 3px solid @scrollbar-background-color;
 		background: @scrollbar-color;
 		background-clip: content-box;
 	}
 
-	/deep/ ::-webkit-scrollbar-corner {
+	::-webkit-scrollbar-corner {
 		background: @scrollbar-background-color;
 	}
 
-	/deep/ ::-webkit-scrollbar-thumb:vertical:active {
+	::-webkit-scrollbar-thumb:vertical:active {
 		border-radius: 0;
 		border-left-width: 0;
 		border-right-width: 0;
 	}
 
-	/deep/ ::-webkit-scrollbar-thumb:horizontal:active {
+	::-webkit-scrollbar-thumb:horizontal:active {
 		border-radius: 0;
 		border-top-width: 0;
 		border-bottom-width: 0;
 	}
 
 	atom-text-editor {
-		/deep/ ::-webkit-scrollbar-track {
+		::-webkit-scrollbar-track {
 			background: @scrollbar-background-color-editor;
 		}
-		/deep/ ::-webkit-scrollbar-corner {
+		::-webkit-scrollbar-corner {
 			background: @scrollbar-background-color-editor;
 		}
-		/deep/ ::-webkit-scrollbar-thumb {
+		::-webkit-scrollbar-thumb {
 			border-color: @scrollbar-background-color-editor;
 			background: @scrollbar-color-editor;
 		}

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -2,9 +2,6 @@ atom-text-editor[mini] {
   line-height: @component-line-height;
   max-height: @component-line-height + 2; // +2 for borders
   overflow: auto;
-}
-
-atom-text-editor[mini] {
   font-size: @ui-input-size;
   line-height: @ui-line-height;
   max-height: none;
@@ -14,22 +11,18 @@ atom-text-editor[mini] {
   border: 1px solid @input-border-color;
   background-color: @input-background-color;
 
-  &,
-  &::shadow {
-    .placeholder-text {
-      color: @text-color-subtle;
-    }
-    .selection .region {
-      background-color: @input-selection-color;
-    }
-    .cursor {
-      border-color: @accent-color;
-      border-width: 2px;
-    }
+  .placeholder-text {
+    color: @text-color-subtle;
+  }
+  .selection .region {
+    background-color: @input-selection-color;
+  }
+  .cursor {
+    border-color: @accent-color;
+    border-width: 2px;
   }
 
-  &.is-focused,
-  &.is-focused::shadow {
+  &.is-focused {
     .focus();
     background-color: @input-background-color-focus;
     .selection .region {


### PR DESCRIPTION
We are in the process of removing the shadow DOM boundary from `atom-text-editor` elements. This pull request upgrades existing selectors so that they:

* Stop using `:host`.
* Stop using `atom-text-editor::shadow`.
* Prepend syntax class names with `syntax--`.

/cc: @simurai