### PR TITLE
Accent color adjustments

### DIFF
--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -42,10 +42,10 @@
     @text-color-highlight
   );
   color: @_text-color;
-  text-shadow: 0 1px 0 hsla(0,0%,0%,.2);
 
   & when (@ui-lightness > 50%) {
     border-color: transparent; // hide border on light backgrounds
+    text-shadow: 0 1px 0 hsla(0,0%,0%,.2);
   }
 
   &:hover,
@@ -74,7 +74,7 @@
 }
 
 .btn.btn-primary {
-  .btn-variant(@accent-color);
+  .btn-variant(@accent-bg-color);
 }
 .btn.btn-info {
   .btn-variant(@background-color-info);

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -9,7 +9,7 @@
   }
   &:before,
   &:after {
-    background-color: @accent-text-on-bg-color;
+    background-color: @accent-text-color;
   }
   &:checked {
     background-color: @accent-color;
@@ -27,7 +27,7 @@
 
 .input-radio {
   &:before {
-    background-color: @accent-text-on-bg-color;
+    background-color: @accent-text-color;
   }
   &:active {
     background-color: @accent-color;
@@ -58,6 +58,6 @@
     background-color: @accent-color;
   }
   &:before {
-    background-color: @accent-text-on-bg-color;
+    background-color: @accent-text-color;
   }
 }

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -118,7 +118,7 @@
 	}
 
 	.install-button {
-		.btn-variant(@accent-color);
+		.btn-variant(@accent-bg-color);
 	}
 
 	input[type="checkbox"] {
@@ -129,7 +129,7 @@
 		}
 		&:before,
 		&:after {
-			background-color: @accent-text-on-bg-color;
+			background-color: @accent-text-color;
 		}
 	}
 

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -99,7 +99,7 @@
       transform: scale(0);
       transition: transform .08s;
       &:hover {
-        color: @accent-text-on-bg-color;
+        color: @accent-text-color;
         background-color: @accent-color;
       }
       &:active {
@@ -169,9 +169,9 @@
   // Modified ----------------------
   .tab.modified {
     &:hover .close-icon {
-      color: @accent-text-color;
+      color: @accent-color;
       &:hover {
-        color: @accent-text-on-bg-color;
+        color: @accent-bg-text-color;
       }
     }
     &:not(:hover) .close-icon {
@@ -180,7 +180,7 @@
       width: 1.5em;
       height: 1.5em;
       line-height: 1.5;
-      color: @accent-text-color;
+      color: @accent-color;
       border: none;
       transform: scale(1);
       &::before {

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -63,11 +63,15 @@
 
 
 // Accent (Custom) -----------------
-@accent-color:            hsl(@ui-hue, 100%, 66%);
-@accent-text-color:       contrast(@accent-color, hsl(@ui-hue,100%,10%), #fff, 33% );
+@accent-luma:             luma( hsl(@ui-hue, 50%, 50%) ); // get lightness of current hue
 
-@accent-bg-color:         mix(hsl(@ui-hue, 100%, 60%), hsl(@ui-hue, @ui-saturation, 44%), 66%);
-@accent-bg-text-color:    contrast(@accent-bg-color, hsl(@ui-hue,100%,10%), #fff, 33% );
+// used for marker, inputs (smaller things)
+@accent-color:            mix( hsv( @ui-hue, 100%, 66%), hsl( @ui-hue, 100%, 70%), @accent-luma ); // mix hsv + hsl (favor mostly hsl)
+@accent-text-color:       contrast(@accent-color, hsl(@ui-hue,100%,10%), #fff, 25% );
+
+// used for button, tooltip (larger things)
+@accent-bg-color:         mix( hsv( @ui-hue, 66%, 66%), hsl( @ui-hue, 66%, 60%), @accent-luma * 2 ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
+@accent-bg-text-color:    contrast(@accent-bg-color, hsl(@ui-hue,100%,10%), #fff, 25% );
 
 
 // Components (Custom) -----------------

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -64,17 +64,19 @@
 
 // Accent (Custom) -----------------
 @accent-color:            hsl(@ui-hue, 100%, 66%);
-@accent-text-color:       lighten(@accent-color, 6%); // A bit lighter when used for smaller things
-@accent-text-on-bg-color: contrast(@accent-color, white, hsl(@ui-hue,100%,10%), 33% );
+@accent-text-color:       contrast(@accent-color, hsl(@ui-hue,100%,10%), #fff, 33% );
+
+@accent-bg-color:         mix(hsl(@ui-hue, 100%, 60%), hsl(@ui-hue, @ui-saturation, 44%), 66%);
+@accent-bg-text-color:    contrast(@accent-bg-color, hsl(@ui-hue,100%,10%), #fff, 33% );
 
 
 // Components (Custom) -----------------
 @badge-background-color:            lighten(@background-color-highlight, 6%);
 
-@button-text-color-selected:        @accent-text-on-bg-color;
+@button-text-color-selected:        @accent-bg-text-color;
 @button-border-color-selected:      @base-border-color;
 
-@checkbox-background-color:         fade(@accent-color, 33%);
+@checkbox-background-color:         fade(@accent-bg-color, 33%);
 
 @input-background-color-focus:      fadein(@input-background-color, 6%);
 @input-selection-color:             darken(@background-color-selected, 6%);
@@ -100,8 +102,8 @@
 
 @tree-view-background-selected-color: lighten(@level-3-color, 5%);
 
-@tooltip-background-color:          @accent-color;
-@tooltip-text-color:                @accent-text-on-bg-color;
+@tooltip-background-color:          @accent-bg-color;
+@tooltip-text-color:                @accent-bg-text-color;
 @tooltip-text-key-color:            @tooltip-background-color;
 @tooltip-background-key-color:      @tooltip-text-color;
 

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -60,7 +60,7 @@
 
 @button-background-color:          @level-1-color;
 @button-background-color-hover:    lighten(@button-background-color, 2%);
-@button-background-color-selected: @accent-color;
+@button-background-color-selected: @accent-bg-color;
 @button-border-color:              @base-border-color;
 
 @tab-bar-background-color:         @level-3-color;


### PR DESCRIPTION
This changes a bit how the accent color gets used.

There are now two accent colors:
- one for larger UI elements like button, tooltip.. 
- and one for smaller elements, like the active pane marker or inputs.

Ref: https://github.com/atom/one-dark-ui/issues/156