### PR TITLE
Shift contrast of accent text color

### DIFF
--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -71,7 +71,7 @@
 
 // used for button, tooltip (larger things)
 @accent-bg-color:         mix( hsv( @ui-hue, 66%, 66%), hsl( @ui-hue, 66%, 60%), @accent-luma * 2 ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
-@accent-bg-text-color:    contrast(@accent-bg-color, hsl(@ui-hue,100%,10%), #fff, 25% );
+@accent-bg-text-color:    contrast(@accent-bg-color, hsl(@ui-hue,100%,10%), #fff, 30% );
 
 
 // Components (Custom) -----------------


### PR DESCRIPTION
Before | After
--- | ---
![screen shot 2016-11-10 at 10 15 42 pm](https://cloud.githubusercontent.com/assets/378023/20178358/1a8bdbaa-a794-11e6-9041-f7222d4f7348.png) | ![screen shot 2016-11-10 at 10 15 26 pm](https://cloud.githubusercontent.com/assets/378023/20178362/1e5a7d68-a794-11e6-9e64-a3d266a1ea9a.png)

This is specially tweaked for the "Atom Material Syntax" theme.

/cc @Ben3eeE 