### PR TITLE
Colorize character matches in the command palette

### DIFF
--- a/styles/key-binding.less
+++ b/styles/key-binding.less
@@ -7,6 +7,6 @@
   font-size: max(1em, @ui-size*.85);
   letter-spacing: @ui-size/10;
   border-radius: @component-border-radius;
-  border: 1px solid @key-binding-border-color;
-  background-color: @key-binding-background-color;
+  color: @accent-bg-text-color;
+  background-color: @accent-bg-color;
 }

--- a/styles/packages.less
+++ b/styles/packages.less
@@ -134,6 +134,15 @@
   }
 }
 
+
+// Command Palette + Fuzzy Finder ---------------------------
+
+.command-palette .list-group .character-match,
+.fuzzy-finder .list-group .character-match {
+  color: @accent-color;
+}
+
+
 // Deprecation Cop ---------------------------
 
 .deprecation-cop {

--- a/styles/packages.less
+++ b/styles/packages.less
@@ -139,7 +139,7 @@
 
 .command-palette .list-group .character-match,
 .fuzzy-finder .list-group .character-match {
-  color: @accent-color;
+  color: @accent-only-text-color;
 }
 
 

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -88,9 +88,6 @@
 @input-selection-color:             mix(@accent-color, @input-background-color, 25%);
 @input-selection-color-focus:       mix(@accent-color, @input-background-color, 50%);
 
-@key-binding-border-color:          hsla(0,0%,100%,.1);
-@key-binding-background-color:      hsla(0,0%,100%,.1);
-
 @overlay-backdrop-color:            hsl(@ui-hue,@ui-saturation,10%);
 @overlay-backdrop-opacity:          .9;
 

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -73,6 +73,8 @@
 @accent-bg-color:         mix( hsv( @ui-hue, 66%, 66%), hsl( @ui-hue, 66%, 60%), @accent-luma * 2 ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
 @accent-bg-text-color:    contrast(@accent-bg-color, hsl(@ui-hue,100%,10%), #fff, 30% );
 
+// used for text only
+@accent-only-text-color: mix( hsv( @ui-hue, 100%, 66%), hsl( @ui-hue, 100%, 77%), @accent-luma ); // mix hsv + hsl (favor mostly hsl)
 
 // Components (Custom) -----------------
 @badge-background-color:            lighten(@background-color-highlight, 6%);


### PR DESCRIPTION
Same as: https://github.com/atom/one-light-ui/pull/87

![screen shot 2016-11-24 at 3 08 59 pm](https://cloud.githubusercontent.com/assets/378023/20588436/705a750e-b258-11e6-866b-fcf8bca4687b.png)
