### PR TITLE
Adjust find-and-replace button widths

### DIFF
--- a/styles/packages.less
+++ b/styles/packages.less
@@ -14,14 +14,14 @@
 .find-and-replace {
   .header,
   .input-block {
-    min-width: @ui-size*25;
+    min-width: @ui-size*22;
   }
 
   .input-block-item {
-    flex: 1 1 @ui-size*25;
+    flex: 1 1 @ui-size*22;
   }
   .input-block-item--flex {
-    flex: 100 1 @ui-size*25;
+    flex: 100 1 @ui-size*22;
   }
 
   .btn,
@@ -55,7 +55,7 @@
   }
 
   .input-block-item {
-    flex: 1 1 @ui-size*20;
+    flex: 1 1 @ui-size*14;
   }
   .input-block-item--flex {
     flex: 100 1 @ui-size*20;


### PR DESCRIPTION
### Description of the Change

This adjusts the button widths of find-and-replace.

### Benefits

Makes them a bit smaller and saves some space.

### Applicable Issues

Change is needed because of https://github.com/atom/find-and-replace/pull/840
