### PR TITLE
Status Bar hover effect

### DIFF
--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -13,7 +13,8 @@
   }
 
   // underlines should only be used for external links
-  a:hover {
+  a:hover,
+  a:focus {
     text-decoration: none;
     cursor: default;
   }
@@ -48,5 +49,33 @@
   	width: auto;
     height: 16px;
     margin-right: 4px;
+  }
+}
+
+
+// Package overrides -------------------------------
+
+.status-bar.status-bar {
+
+  // Read-only -> Remove hover effect
+  status-bar-launch-mode,
+  status-bar-cursor,
+  busy-signal {
+    &:hover,
+    &:active,
+    .inline-block:hover,
+    .inline-block:active {
+      background-color: transparent;
+    }
+  }
+
+  // Remove underline
+  .package-updates-status-view,
+  .github-ChangedFilesCount {
+    &:hover,
+    &:focus {
+      text-decoration: none;
+      cursor: default;
+    }
   }
 }

--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -58,6 +58,7 @@
 .status-bar.status-bar {
 
   // Read-only -> Remove hover effect
+  .is-read-only, // <- use this class in packages
   status-bar-launch-mode,
   status-bar-cursor,
   busy-signal {

--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -9,30 +9,44 @@
   background-color: @level-3-color;
 
   .flexbox-repaint-hack {
-    padding: 0 @status-bar-padding/2;
+    padding: 0; // override default
+  }
+
+  // underlines should only be used for external links
+  a:hover {
+    text-decoration: none;
+    cursor: default;
   }
 
   .inline-block {
-    margin-right: @status-bar-padding;
+    margin: 0; // override default
+    padding: 0 @status-bar-padding/2;
     vertical-align: top;
+
+    &:hover {
+      background-color: @background-color-highlight;
+    }
+    &:active {
+      background-color: mix(@background-color-highlight, @level-3-color);
+    }
+
+    // reset on child inline-block
+    .inline-block {
+      margin: 0;
+      padding: 0;
+    }
   }
 
   .status-bar-right {
     .inline-block {
-      margin-right: 0;
-      margin-left: @status-bar-padding;
-      & > .inline-block {
-        margin-left: 0;
-      }
-    }
-    .icon {
-      margin-right: @status-bar-padding/8;
+      margin-left: 0; // override default
     }
   }
 
   .icon::before {
     font-size: 16px; // keeps them sharp
-  	width: 16px;
+  	width: auto;
     height: 16px;
+    margin-right: 4px;
   }
 }

--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -25,10 +25,10 @@
     vertical-align: top;
 
     &:hover {
-      background-color: @background-color-highlight;
+      background-color: @level-3-color-hover;
     }
     &:active {
-      background-color: mix(@background-color-highlight, @level-3-color);
+      background-color: @level-3-color-active;
     }
 
     // reset on child inline-block

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -62,6 +62,9 @@
 @level-2-color: @base-background-color;
 @level-3-color: darken(@base-background-color, 3%);
 
+@level-3-color-hover:  lighten(@level-3-color, 6%);
+@level-3-color-active: lighten(@level-3-color, 3%);
+
 
 // Accent (Custom) -----------------
 @accent-luma:             luma( hsl(@ui-hue, 50%, 50%) ); // get lightness of current hue


### PR DESCRIPTION
### Description of the Change

This replaces the underlines in the Status Bar with highlighting the background on hover.

Before | After
--- | ---
![status-bar](https://user-images.githubusercontent.com/378023/27718730-c28b865c-5d88-11e7-801e-6f725cc0506e.gif) | ![status-bar-after](https://user-images.githubusercontent.com/378023/27718729-c27fb976-5d88-11e7-9432-fd08be6e33f5.gif)


### Alternate Designs

More like a button with rounded corners:

![image](https://user-images.githubusercontent.com/378023/27718979-73d1d8e8-5d8a-11e7-8ec7-981beb0e6b9e.png)

Might look nicer, but makes the click target smaller.


### Benefits

Makes all clicky things more consistent. Underlines should only be used for **external links**.


### Possible Drawbacks

As mentioned here https://github.com/atom/status-bar/issues/196#issuecomment-311899047, there isn't a convention/API around Status Bar tiles. So it currently adds a hover effect on **all** `inline-block`s and resets a few bundled packages. But there is a chance that some community packages don't use that class. Also if a tile isn't clickable, package could add the `is-read-only`, but that's undocumented and only used by this theme.

Would be great to extend the API to add the same class to all tiles and an option to specify if a tile is click-able or not.


### Applicable Issues

Closes https://github.com/atom/status-bar/issues/196
