### PR TITLE
Center tree-view arrow icon

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -56,6 +56,20 @@
   }
 }
 
+// Arrow icon
+.list-group,
+.list-tree {
+  .header.header.header.header::before {
+    top: initial;
+    line-height: inherit;
+    height: inherit;
+    vertical-align: top;
+  }
+}
+.tree-view .project-root-header.project-root-header.project-root-header.project-root-header::before {
+  line-height: 2.5em;
+}
+
 // Active tree-view marker --------------
 
 .tree-view::before {


### PR DESCRIPTION
### Description of the Change

This vertically centers the arrow icon in the tree-view.

### Alternate Designs

- We could fix it in the tree-view package, but it's not broken for all themes.
- It's not pixel perfect (off by `1px`), but it still adapts to different font sizes.

### Benefits

More visually pleasing.

Before | After
--- | ---
<img width="564" alt="closeup" src="https://user-images.githubusercontent.com/460323/29326164-7593c086-81b8-11e7-804f-c5a1088f405f.png"> | ![image](https://user-images.githubusercontent.com/378023/29342560-66cc3020-8266-11e7-82cf-5d0416e678fc.png)


### Possible Drawbacks

- One theme forks still have this issue.

### Applicable Issues

Fixes https://github.com/atom/tree-view/issues/1163
Related https://github.com/atom/one-light-ui/pull/105