### PR TITLE
Center project root icon

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -64,10 +64,11 @@
     line-height: inherit;
     height: inherit;
     vertical-align: top;
+    font-size: inherit;
   }
 }
 .tree-view .project-root-header.project-root-header.project-root-header.project-root-header::before {
-  line-height: 2.5em;
+  line-height: @ui-tab-height;
 }
 
 // Active tree-view marker --------------


### PR DESCRIPTION
### Description of the Change

This PR centers the `>` arrow icon of the project root by using the same font-size as the label.

![icon](https://user-images.githubusercontent.com/378023/33591384-aae13cec-d9c8-11e7-8043-0c6bbf125092.gif)

### Benefits

Centered icon

### Possible Drawbacks

With larger font sizes, the arrow icon might get too close to the folder icon.

### Applicable Issues

Fixes #222
