### PR TITLE
Replace tree-view focus indicator

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -15,7 +15,12 @@
   }
 
   .selected:before {
-    background: @tree-view-background-selected-color;
+    background: @background-color-selected;
+  }
+
+  &:focus .selected:before {
+    color: contrast(@button-background-color-selected);
+    background: @button-background-color-selected;
   }
 }
 
@@ -69,23 +74,4 @@
 }
 .tree-view .project-root-header.project-root-header.project-root-header.project-root-header::before {
   line-height: @ui-tab-height;
-}
-
-// Active tree-view marker --------------
-
-.tree-view::before {
-  content: "";
-  position: fixed;
-  pointer-events: none;
-  z-index: 1;
-  height: @ui-tab-height;
-  width: 2px;
-  background: @accent-color;
-  opacity: 0;
-  transition: opacity .16s;
-}
-
-.tree-view:focus::before {
-  opacity: 1;
-  transition-duration: .32s;
 }

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -108,7 +108,6 @@
 @tab-text-color-editor:             contrast(@ui-syntax-color, darken(@ui-syntax-color, 50%), @text-color-highlight );
 @tab-background-color-editor:       @ui-syntax-color;
 
-@tree-view-background-selected-color: lighten(@level-3-color, 5%);
 
 @tooltip-background-color:          @accent-bg-color;
 @tooltip-text-color:                @accent-bg-text-color;


### PR DESCRIPTION
### Description of the Change

This replaces the blue "stripe" indicator with a background for the selected item when the tree-view gets focus.

Before | After
--- | ---
![screen shot 2017-12-05 at 4 31 26 pm](https://user-images.githubusercontent.com/378023/33595057-c90276d0-d9d9-11e7-9e5a-b8b88db21b60.png) | ![image](https://user-images.githubusercontent.com/378023/33595029-b29f4b70-d9d9-11e7-9128-f4626fcda5b3.png)

### Benefits

It's more consistent with the GitHub package and also Atom IDE UI.

![focus](https://user-images.githubusercontent.com/378023/33595258-b0849bf0-d9da-11e7-89c9-dfa8e8b75883.gif)

### Possible Drawbacks

- A downside is that when the selected item gets scrolled out of sight, you can't tell anymore that the tree-view has focus.
- Another one: The colors might clash when files are modified/added.

### Applicable Issues

Based on: https://github.com/atom/one-dark-ui/issues/52#issuecomment-333024501
