### PR TITLE
Fade VCS colored non-active tabs

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -62,6 +62,10 @@
       margin: 0 @title-padding;
     }
 
+    // VCS coloring ----------------------
+    &:not(.active) .status-added { color: fade(@text-color-success, 55%) }
+    &:not(.active) .status-modified { color: fade(@text-color-warning, 55%) }
+
 
     // Icons ----------------------
 

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -63,8 +63,8 @@
     }
 
     // VCS coloring ----------------------
-    &:not(.active) .status-added { color: fade(@text-color-success, 55%) }
-    &:not(.active) .status-modified { color: fade(@text-color-warning, 55%) }
+    &:not(.active) .status-added    { color: @tab-inactive-status-added; }
+    &:not(.active) .status-modified { color: @tab-inactive-status-modified; }
 
 
     // Icons ----------------------

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -107,6 +107,8 @@
 @tab-text-color-active:             @text-color-highlight;
 @tab-text-color-editor:             contrast(@ui-syntax-color, darken(@ui-syntax-color, 50%), @text-color-highlight );
 @tab-background-color-editor:       @ui-syntax-color;
+@tab-inactive-status-added:         fade(@text-color-success, 55%);
+@tab-inactive-status-modified:      fade(@text-color-warning, 55%);
 
 @tree-view-background-selected-color: lighten(@level-3-color, 5%);
 


### PR DESCRIPTION
### Description of the Change

Fades VCS colored tabs that are not active.

#### Before

![image](https://user-images.githubusercontent.com/378023/33694626-8bfde7f6-db3c-11e7-985a-a66673141406.png)

#### After

![vcs](https://user-images.githubusercontent.com/378023/33694631-91390944-db3c-11e7-86ab-ddb979f51385.gif)


### Alternate Designs

Instead of using color for VCS, there could be modified/added icons. Or other indicators. But they would need extra space.

### Benefits

Makes the active tab stand out more.

### Possible Drawbacks

Decreases contrast and some people might like to have modified/added tabs be stronger.

### Applicable Issues

Closes #226
