### PR TITLE
Fix dock toggle button position

### DIFF
--- a/styles/docks.less
+++ b/styles/docks.less
@@ -33,10 +33,10 @@
 
 // Make toggle buttons cover ^ border
 .atom-dock-toggle-button.left {
-  margin-left: -1px;
+  margin-left: -2px;
 }
 .atom-dock-toggle-button.right {
-  margin-right: -1px;
+  margin-right: -2px;
 }
 .atom-dock-inner:not(.atom-dock-open) .atom-dock-toggle-button.bottom {
   margin-bottom: -1px;


### PR DESCRIPTION
### Description of the Change

This PR adjust the dock toggle button position.

### Benefits

Removes the `1px` gap introduced in https://github.com/atom/atom/pull/16414

![screen shot 2017-12-20 at 7 52 19 pm](https://user-images.githubusercontent.com/378023/34204122-e9ca516a-e5c0-11e7-9ad6-a97cf5127fd3.png)

### Possible Drawbacks

None

### Applicable Issues

https://github.com/atom/atom/pull/16414
