### PR TITLE
Increase transparency of the modal backdrop

### DIFF
--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -92,8 +92,8 @@
 @input-selection-color:             mix(@accent-color, @input-background-color, 25%);
 @input-selection-color-focus:       mix(@accent-color, @input-background-color, 50%);
 
-@overlay-backdrop-color:            hsl(@ui-hue,@ui-saturation,10%);
-@overlay-backdrop-opacity:          .9;
+@overlay-backdrop-color:            hsl(@ui-hue, @ui-saturation, @ui-lightness*0.2);
+@overlay-backdrop-opacity:          .75;
 
 @progress-background-color:         @accent-color;
 


### PR DESCRIPTION
### Description of the Change

This PR increases the transparency of the modal backdrop

Before | After
--- | ---
![screen shot 2018-03-08 at 12 15 35 pm](https://user-images.githubusercontent.com/378023/37131700-f8ba5532-22cc-11e8-923e-1c19ce50c721.png) | ![screen shot 2018-03-08 at 12 28 53 pm](https://user-images.githubusercontent.com/378023/37131699-f8931bac-22cc-11e8-8499-fc36e8aafc14.png)

### Benefits

Things underneath are a bit easier to read.

### Possible Drawbacks

There is less visual focus on the modal alone.

### Applicable Issues

Closes #240
