### PR TITLE
Fix command palette input border

### DIFF
--- a/styles/modal.less
+++ b/styles/modal.less
@@ -80,6 +80,11 @@ atom-panel.modal {
     position: relative; // fixes stacking order
   }
 
+  .command-palette {
+    padding: 1px; // prevents the box-shadow of the input from being cut off
+    background-color: @overlay-background-color;
+  }
+
 
   // Container
   &:before {


### PR DESCRIPTION
### Description of the Change

Fixes the focus border from being cut off.

Before | After
--- | ---
![screen shot 2018-03-08 at 2 03 09 pm](https://user-images.githubusercontent.com/378023/37133963-7ddcd670-22d9-11e8-9aee-2f80a948a05a.png) | ![screen shot 2018-03-08 at 2 03 19 pm](https://user-images.githubusercontent.com/378023/37133968-809491be-22d9-11e8-90da-e03a4ca4617e.png)

### Benefits

Easier on the 👀 

### Possible Drawbacks

None
