### PR TITLE
Use dropdown as font size picker

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -25,10 +25,7 @@ module.exports =
 # Font Size -----------------------
 
 setFontSize = (currentFontSize) ->
-  if Number.isInteger(currentFontSize)
-    root.style.fontSize = "#{currentFontSize}px"
-  else if currentFontSize is 'Auto'
-    unsetFontSize()
+  root.style.fontSize = "#{currentFontSize}px"
 
 unsetFontSize = ->
   root.style.fontSize = ''

--- a/package.json
+++ b/package.json
@@ -20,14 +20,10 @@
   "configSchema": {
     "fontSize": {
       "title": "Font Size",
-      "description": "Change the UI font size. Needs to be between 8 and 20. In Auto mode, the Font Size will automatically change based on the window size.",
-      "type": [
-        "integer",
-        "string"
-      ],
-      "minimum": 8,
-      "maximum": 20,
-      "default": "Auto",
+      "description": "Change the font size for the UI.",
+      "type": "integer",
+      "default": 12,
+      "enum": [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
       "order": 1
     },
     "tabSizing": {

--- a/spec/theme-spec.coffee
+++ b/spec/theme-spec.coffee
@@ -4,13 +4,10 @@ describe "One Dark UI theme", ->
       atom.packages.activatePackage('one-dark-ui')
 
   it "allows the font size to be set via config", ->
-    expect(document.documentElement.style.fontSize).toBe ''
+    expect(document.documentElement.style.fontSize).toBe '12px'
 
     atom.config.set('one-dark-ui.fontSize', '10')
     expect(document.documentElement.style.fontSize).toBe '10px'
-
-    atom.config.set('one-dark-ui.fontSize', 'Auto')
-    expect(document.documentElement.style.fontSize).toBe ''
 
   it "allows the tab sizing to be set via config", ->
     atom.config.set('one-dark-ui.tabSizing', 'Maximum')


### PR DESCRIPTION
### Description of the Change

This changes the font size picker to a dropdown instead of a text input.

![one](https://user-images.githubusercontent.com/378023/37138394-4433e45e-22ed-11e8-881d-6039ea63a112.gif)

### Alternate Designs

Add a longer delay when typing a number.

### Benefits

Fixes the following problem with a text input:

1. if you are at `11` and want to go to `12`, you hit delete and it goes to `1`.
2. Because `1` is too small, it automatically changes to `8` (the minimum font size).
3. Then you type `2`. Which is now `82`. But since that is over the maximum, it changes to `20`.

### Possible Drawbacks

Not as quick as a text input to change to a different number.

### Applicable Issues

Ref https://github.com/atom/one-light-ui/issues/47
