### PR TITLE
Increase contrast of scrollbar thumb

### DIFF
--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -97,9 +97,9 @@
 
 @progress-background-color:         @accent-color;
 
-@scrollbar-color:                   @level-1-color;
+@scrollbar-color:                   lighten(@ui-syntax-color, 16%);
 @scrollbar-background-color:        @level-3-color; // replaced `transparent` with a solid color to test https://github.com/atom/one-light-ui/issues/4
-@scrollbar-color-editor:            contrast(@ui-syntax-color, darken(@ui-syntax-color, 18%), lighten(@ui-syntax-color, 9%) );
+@scrollbar-color-editor:            lighten(@ui-syntax-color, 16%);
 @scrollbar-background-color-editor: @ui-syntax-color;
 
 


### PR DESCRIPTION
### Description of the Change

This adds more contrast to the scrollbar thumb.

Before | After
--- | ---
![screen shot 2018-03-12 at 5 36 15 pm](https://user-images.githubusercontent.com/378023/37273058-ee48c816-261b-11e8-948d-b725e8e7f9d1.png) | ![screen shot 2018-03-12 at 5 35 55 pm](https://user-images.githubusercontent.com/378023/37273057-ee1a21e6-261b-11e8-99b1-fc6d1c93b269.png)

### Benefits

Easier to see

### Possible Drawbacks

Too strong.

### Applicable Issues

Closes #241
