### PR TITLE
Fix tabs.less

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -215,16 +215,19 @@
 
 // Active pane marker --------------
 
-atom-pane.active .tab.active:before {
-  content: "";
-  position: absolute;
-  pointer-events: none;
-  z-index: 2;
-  top: 0;
-  left: -1px; // cover left border
-  bottom: 0;
-  width: 2px;
-  background: @accent-color;
+atom-pane-axis > atom-pane.active,
+atom-pane-container > atom-pane.pane {
+  .tab.active:before {
+    content: "";
+    position: absolute;
+    pointer-events: none;
+    z-index: 2;
+    top: 0;
+    left: -1px; // cover left border
+    bottom: 0;
+    width: 2px;
+    background: @accent-color;
+  }
 }
 
 // hide marker in docks


### PR DESCRIPTION
After you install and disable the welcome plug and enable one-dark-ui > hide dock toggle button, the activity indicator of the tab disappears.

![img_2018-03-17_ _11_23_51](https://user-images.githubusercontent.com/16165904/37553282-fe0b978e-29d5-11e8-8312-2bd1153382c2.png)
