### PR TITLE
Sticky header config

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -11,6 +11,9 @@ module.exports =
     atom.config.observe 'one-dark-ui.hideDockButtons', (value) ->
       setHideDockButtons(value)
 
+    atom.config.observe 'one-dark-ui.stickyHeaders', (value) ->
+      setStickyHeaders(value)
+
     # DEPRECATED: This can be removed at some point (added in Atom 1.17/1.18ish)
     # It removes `layoutMode`
     if atom.config.get('one-dark-ui.layoutMode')
@@ -20,6 +23,7 @@ module.exports =
     unsetFontSize()
     unsetTabSizing()
     unsetHideDockButtons()
+    unsetStickyHeaders()
 
 
 # Font Size -----------------------
@@ -50,3 +54,15 @@ setHideDockButtons = (hideDockButtons) ->
 
 unsetHideDockButtons = ->
   root.removeAttribute('theme-one-dark-ui-dock-buttons')
+
+
+# Sticky Headers -----------------------
+
+setStickyHeaders = (stickyHeaders) ->
+  if stickyHeaders
+    root.setAttribute('theme-one-dark-ui-sticky-headers', 'sticky')
+  else
+    unsetStickyHeaders()
+
+unsetStickyHeaders = ->
+  root.removeAttribute('theme-one-dark-ui-sticky-headers')

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,23 +1,25 @@
 root = document.documentElement
+themeName = 'one-dark-ui'
+
 
 module.exports =
   activate: (state) ->
-    atom.config.observe 'one-dark-ui.fontSize', (value) ->
+    atom.config.observe "#{themeName}.fontSize", (value) ->
       setFontSize(value)
 
-    atom.config.observe 'one-dark-ui.tabSizing', (value) ->
+    atom.config.observe "#{themeName}.tabSizing", (value) ->
       setTabSizing(value)
 
-    atom.config.observe 'one-dark-ui.hideDockButtons', (value) ->
+    atom.config.observe "#{themeName}.hideDockButtons", (value) ->
       setHideDockButtons(value)
 
-    atom.config.observe 'one-dark-ui.stickyHeaders', (value) ->
+    atom.config.observe "#{themeName}.stickyHeaders", (value) ->
       setStickyHeaders(value)
 
     # DEPRECATED: This can be removed at some point (added in Atom 1.17/1.18ish)
     # It removes `layoutMode`
-    if atom.config.get('one-dark-ui.layoutMode')
-      atom.config.unset('one-dark-ui.layoutMode')
+    if atom.config.get("#{themeName}.layoutMode")
+      atom.config.unset("#{themeName}.layoutMode")
 
   deactivate: ->
     unsetFontSize()
@@ -38,31 +40,31 @@ unsetFontSize = ->
 # Tab Sizing -----------------------
 
 setTabSizing = (tabSizing) ->
-  root.setAttribute('theme-one-dark-ui-tabsizing', tabSizing.toLowerCase())
+  root.setAttribute("theme-#{themeName}-tabsizing", tabSizing.toLowerCase())
 
 unsetTabSizing = ->
-  root.removeAttribute('theme-one-dark-ui-tabsizing')
+  root.removeAttribute("theme-#{themeName}-tabsizing")
 
 
 # Dock Buttons -----------------------
 
 setHideDockButtons = (hideDockButtons) ->
   if hideDockButtons
-    root.setAttribute('theme-one-dark-ui-dock-buttons', 'hidden')
+    root.setAttribute("theme-#{themeName}-dock-buttons", 'hidden')
   else
     unsetHideDockButtons()
 
 unsetHideDockButtons = ->
-  root.removeAttribute('theme-one-dark-ui-dock-buttons')
+  root.removeAttribute("theme-#{themeName}-dock-buttons")
 
 
 # Sticky Headers -----------------------
 
 setStickyHeaders = (stickyHeaders) ->
   if stickyHeaders
-    root.setAttribute('theme-one-dark-ui-sticky-headers', 'sticky')
+    root.setAttribute("theme-#{themeName}-sticky-headers", 'sticky')
   else
     unsetStickyHeaders()
 
 unsetStickyHeaders = ->
-  root.removeAttribute('theme-one-dark-ui-sticky-headers')
+  root.removeAttribute("theme-#{themeName}-sticky-headers")

--- a/package.json
+++ b/package.json
@@ -56,6 +56,12 @@
       "type": "boolean",
       "default": "false",
       "order": 3
+    },
+    "stickyHeaders": {
+      "title": "Make tree-view project headers sticky",
+      "type": "boolean",
+      "default": "true",
+      "order": 4
     }
   }
 }

--- a/spec/theme-spec.coffee
+++ b/spec/theme-spec.coffee
@@ -1,30 +1,32 @@
-describe "One Dark UI theme", ->
+themeName = 'one-dark-ui'
+
+describe "#{themeName} theme", ->
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage('one-dark-ui')
+      atom.packages.activatePackage(themeName)
 
   it "allows the font size to be set via config", ->
     expect(document.documentElement.style.fontSize).toBe '12px'
 
-    atom.config.set('one-dark-ui.fontSize', '10')
+    atom.config.set("#{themeName}.fontSize", '10')
     expect(document.documentElement.style.fontSize).toBe '10px'
 
   it "allows the tab sizing to be set via config", ->
-    atom.config.set('one-dark-ui.tabSizing', 'Maximum')
-    expect(document.documentElement.getAttribute('theme-one-dark-ui-tabsizing')).toBe 'maximum'
+    atom.config.set("#{themeName}.tabSizing", 'Maximum')
+    expect(document.documentElement.getAttribute("theme-#{themeName}-tabsizing")).toBe 'maximum'
 
   it "allows the tab sizing to be set via config", ->
-    atom.config.set('one-dark-ui.tabSizing', 'Minimum')
-    expect(document.documentElement.getAttribute('theme-one-dark-ui-tabsizing')).toBe 'minimum'
+    atom.config.set("#{themeName}.tabSizing", 'Minimum')
+    expect(document.documentElement.getAttribute("theme-#{themeName}-tabsizing")).toBe 'minimum'
 
   it "allows the dock toggle buttons to be hidden via config", ->
-    atom.config.set('one-dark-ui.hideDockButtons', true)
-    expect(document.documentElement.getAttribute('theme-one-dark-ui-dock-buttons')).toBe 'hidden'
+    atom.config.set("#{themeName}.hideDockButtons", true)
+    expect(document.documentElement.getAttribute("theme-#{themeName}-dock-buttons")).toBe 'hidden'
 
   it "allows the tree-view headers to be sticky via config", ->
-    atom.config.set('one-dark-ui.stickyHeaders', true)
-    expect(document.documentElement.getAttribute('theme-one-dark-ui-sticky-headers')).toBe 'sticky'
+    atom.config.set("#{themeName}.stickyHeaders", true)
+    expect(document.documentElement.getAttribute("theme-#{themeName}-sticky-headers")).toBe 'sticky'
 
   it "allows the tree-view headers to not be sticky via config", ->
-    atom.config.set('one-dark-ui.stickyHeaders', false)
-    expect(document.documentElement.getAttribute('theme-one-dark-ui-sticky-headers')).toBe null
+    atom.config.set("#{themeName}.stickyHeaders", false)
+    expect(document.documentElement.getAttribute("theme-#{themeName}-sticky-headers")).toBe null

--- a/spec/theme-spec.coffee
+++ b/spec/theme-spec.coffee
@@ -20,3 +20,11 @@ describe "One Dark UI theme", ->
   it "allows the dock toggle buttons to be hidden via config", ->
     atom.config.set('one-dark-ui.hideDockButtons', true)
     expect(document.documentElement.getAttribute('theme-one-dark-ui-dock-buttons')).toBe 'hidden'
+
+  it "allows the tree-view headers to be sticky via config", ->
+    atom.config.set('one-dark-ui.stickyHeaders', true)
+    expect(document.documentElement.getAttribute('theme-one-dark-ui-sticky-headers')).toBe 'sticky'
+
+  it "allows the tree-view headers to not be sticky via config", ->
+    atom.config.set('one-dark-ui.stickyHeaders', false)
+    expect(document.documentElement.getAttribute('theme-one-dark-ui-sticky-headers')).toBe null

--- a/styles/config.less
+++ b/styles/config.less
@@ -3,6 +3,7 @@
 
 @theme-tabsizing: ~'theme-@{ui-theme-name}-tabsizing';
 @theme-dockButtons: ~'theme-@{ui-theme-name}-dock-buttons';
+@theme-stickyHeaders: ~'theme-@{ui-theme-name}-sticky-headers';
 
 @tab-min-width: 7em; // ~ icon + 6 characters
 
@@ -74,4 +75,39 @@
     display: none;
   }
 
+}
+
+
+// Sticky Projects ------------------------------
+
+[@{theme-stickyHeaders}="sticky"] {
+
+  .tree-view {
+    .project-root-header {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      padding-left: 5px;
+      padding-right: 10px;
+      border-bottom: 1px solid @base-border-color;
+      background-color: @tree-view-background-color;
+    }
+    .project-root.project-root {
+      margin-left: -5px;
+      margin-right: -10px;
+
+      // Disable selection
+      &::before {
+        display: none;
+      }
+
+      // Add selection back
+      &.selected .project-root-header {
+        background-color: @background-color-selected;
+      }
+    }
+    &:focus .selected .project-root-header.project-root-header  {
+      background: @button-background-color-selected;
+    }
+  }
 }

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -83,35 +83,3 @@
 .tree-view .project-root-header.project-root-header.project-root-header.project-root-header::before {
   line-height: @ui-tab-height;
 }
-
-
-// Sticky Projects ------------------------------
-
-.tree-view {
-  .project-root-header {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    padding-left: 5px;
-    padding-right: 10px;
-    border-bottom: 1px solid @base-border-color;
-    background-color: @tree-view-background-color;
-  }
-  .project-root.project-root {
-    margin-left: -5px;
-    margin-right: -10px;
-
-    // Disable selection
-    &::before {
-      display: none;
-    }
-
-    // Add selection back
-    &.selected .project-root-header {
-      background-color: @background-color-selected;
-    }
-  }
-  &:focus .selected .project-root-header.project-root-header  {
-    background: @button-background-color-selected;
-  }
-}


### PR DESCRIPTION
### Description of the Change

Add config setting to enable/disable sticky tree-view headers (Default is enabled)

![setting](https://user-images.githubusercontent.com/97994/37616882-48b64a0e-2b7f-11e8-8e87-2f93df335994.png)

![screenshot](https://user-images.githubusercontent.com/97994/37616892-4d674fbc-2b7f-11e8-8d83-71d0c6192b39.gif)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

User can opt out of sticky tree-view headers

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

none
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

#249
<!-- Enter any applicable Issues here -->
