### PR TITLE
Fix sticky header from covering auto-revealed items

### DIFF
--- a/styles/config.less
+++ b/styles/config.less
@@ -109,5 +109,11 @@
     &:focus .selected .project-root-header.project-root-header  {
       background: @button-background-color-selected;
     }
+
+    // Fix sticky header from covering auto-revealed items
+    .list-item.selected {
+      padding-top: @ui-tab-height;
+      margin-top: -@ui-tab-height;
+    }
   }
 }


### PR DESCRIPTION
### Description of the Change

This fixes the sticky headers from covering auto-revealed items in the tree-view. See this comment for more details: https://github.com/atom/one-dark-ui/pull/246#issuecomment-376458967

![tree-view](https://user-images.githubusercontent.com/378023/37958695-1bf4f786-31ec-11e8-83f5-31db028b699c.gif)

### Alternate Designs

Use JS to change the scroll position. But better to keep it theme only.

### Benefits

Item is visible when auto-revealed

### Possible Drawbacks

There could be side effects.

### Applicable Issues

This is a follow-up fix for #246.
