### PR TITLE
Add option for left tab close buttons

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,6 +10,9 @@ module.exports =
     atom.config.observe "#{themeName}.tabSizing", (value) ->
       setTabSizing(value)
 
+    atom.config.observe "#{themeName}.tabCloseButton", (value) ->
+      setTabCloseButton(value)
+
     atom.config.observe "#{themeName}.hideDockButtons", (value) ->
       setHideDockButtons(value)
 
@@ -24,6 +27,7 @@ module.exports =
   deactivate: ->
     unsetFontSize()
     unsetTabSizing()
+    unsetTabCloseButton()
     unsetHideDockButtons()
     unsetStickyHeaders()
 
@@ -44,6 +48,18 @@ setTabSizing = (tabSizing) ->
 
 unsetTabSizing = ->
   root.removeAttribute("theme-#{themeName}-tabsizing")
+
+
+# Tab Close Button -----------------------
+
+setTabCloseButton = (tabCloseButton) ->
+  if tabCloseButton is 'Left'
+    root.setAttribute("theme-#{themeName}-tab-close-button", 'left')
+  else
+    unsetTabCloseButton()
+
+unsetTabCloseButton = ->
+  root.removeAttribute("theme-#{themeName}-tab-close-button")
 
 
 # Dock Buttons -----------------------

--- a/package.json
+++ b/package.json
@@ -50,18 +50,29 @@
       ],
       "order": 2
     },
+    "tabCloseButton": {
+      "title": "Tab Close Button",
+      "description": "Choose the position of the close button shown in tabs.",
+      "type": "string",
+      "default": "Right",
+      "enum": [
+        "Left",
+        "Right"
+      ],
+      "order": 3
+    },
     "hideDockButtons": {
       "title": "Hide dock toggle buttons",
       "description": "Note: When hiding the toggle buttons, opening a dock needs to be done by using the keyboard or other alternatives.",
       "type": "boolean",
       "default": "false",
-      "order": 3
+      "order": 4
     },
     "stickyHeaders": {
       "title": "Make tree-view project headers sticky",
       "type": "boolean",
       "default": "true",
-      "order": 4
+      "order": 5
     }
   }
 }

--- a/spec/theme-spec.coffee
+++ b/spec/theme-spec.coffee
@@ -19,6 +19,10 @@ describe "#{themeName} theme", ->
     atom.config.set("#{themeName}.tabSizing", 'Minimum')
     expect(document.documentElement.getAttribute("theme-#{themeName}-tabsizing")).toBe 'minimum'
 
+  it "allows the tab close button to be shown on the left via config", ->
+    atom.config.set("#{themeName}.tabCloseButton", 'Left')
+    expect(document.documentElement.getAttribute("theme-#{themeName}-tab-close-button")).toBe 'left'
+
   it "allows the dock toggle buttons to be hidden via config", ->
     atom.config.set("#{themeName}.hideDockButtons", true)
     expect(document.documentElement.getAttribute("theme-#{themeName}-dock-buttons")).toBe 'hidden'

--- a/styles/config.less
+++ b/styles/config.less
@@ -1,14 +1,18 @@
 
-// Tabs ----------------------------------------------
+// Theme config
+// This gets changed from the theme settings
 
 @theme-tabsizing: ~'theme-@{ui-theme-name}-tabsizing';
 @theme-dockButtons: ~'theme-@{ui-theme-name}-dock-buttons';
 @theme-stickyHeaders: ~'theme-@{ui-theme-name}-sticky-headers';
+@theme-closeButton: ~'theme-@{ui-theme-name}-tab-close-button';
+
+
+// Tabs ----------------------------------------------
 
 @tab-min-width: 7em; // ~ icon + 6 characters
 
-
-// Even (default) ---------------
+// Even (default)
 
 .tab-bar {
   .tab,
@@ -32,7 +36,7 @@
 }
 
 
-// Maximum (full width) ---------------
+// Maximum (full width)
 
 [@{theme-tabsizing}="maximum"] .tab-bar {
   .tab,
@@ -42,7 +46,7 @@
 }
 
 
-// Minimum (show long paths) ---------------
+// Minimum (show long paths)
 
 [@{theme-tabsizing}="minimum"] .tab-bar {
   .tab,
@@ -59,6 +63,19 @@
   }
 }
 
+
+// Tabs: close button position  ------------------------------
+
+[@{theme-closeButton}="left"] {
+
+  .tab-bar .tab {
+    .close-icon {
+      right: auto;
+      left: @icon-padding-right;
+    }
+  }
+
+}
 
 
 // Hide docks toggle buttons ------------------------------


### PR DESCRIPTION
### Description of the Change

This adds a config option to move the close buttons shown in tabs to the ⬅️ **left**.

![close-button](https://user-images.githubusercontent.com/378023/38069096-9572002c-334f-11e8-94be-6c417c29db60.gif)

### Benefits

More familiar for people that are used to have them on the left, like in native apps on macOS.

### Possible Drawbacks

Maintenance cost.

### Applicable Issues

Closes #202