### PR TITLE
List item bullet alignment fix

### DIFF
--- a/styles/text.less
+++ b/styles/text.less
@@ -15,6 +15,7 @@ p {
 
 label {
   font-weight: normal;
+  vertical-align: top;
 }
 
 pre {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This change adds a `vertical-align` style to the `label` tag. 

### Alternate Designs

I found no other way to apply this change - had no effect on the `li` or `ul` styles.

Could specify for `label`s that are children of a `.markdown-preview` to avoid the possible drawback listed below.

### Benefits

When creating checkboxes in markdown, the markdown preview shows the list-style image aligned to the bottom of the list item when it wraps lines.

![image](https://user-images.githubusercontent.com/39604995/40891503-affa2940-6754-11e8-932b-4e4da793c99d.png)
*Note the circle displaying next to "element" and "game" in the preview on the right*

By adding `vertical-align: top` to the label, the circle image is covered by the checkbox, as expected.

### Possible Drawbacks

Could negatively affect other `label` stylings across Atom.

### Applicable Issues

I saw no open issues relating to this.
